### PR TITLE
Add/inspira UI

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -117,6 +117,12 @@ export default async function Home() {
       description: "Skiper UI - Un-common Components for shadcn/ui | Skiper UI",
       url: "https://skiper-ui.com/"
     }
+    ,
+    {
+      name: "Inspira UI",
+      description: "A modern component registry with ready-to-use shadcn/ui components.",
+      url: "https://inspira-ui.com/"
+    }
   ];
   return (
     <main className="flex min-h-screen flex-col items-center justify-center py-20">

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -25,6 +25,11 @@ export const metadata: Metadata = {
 export default async function Home() {
   const entries: DirectoryEntry[] = [
     {
+      name: "Pure UI",
+      description: "Enhanced shadcn/ui components with advanced functionality and design patterns.",
+      url: "https://pure.ui.pub/"
+    },
+    {
       name: "shadcn/ui",
       description: "The official registry for shadcn/ui components.",
       url: "https://ui.shadcn.com/",

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -24,11 +24,7 @@ export const metadata: Metadata = {
 
 export default async function Home() {
   const entries: DirectoryEntry[] = [
-    {
-      name: "Pure UI",
-      description: "Enhanced shadcn/ui components with advanced functionality and design patterns.",
-      url: "https://pure.ui.pub/"
-    },
+    
     {
       name: "shadcn/ui",
       description: "The official registry for shadcn/ui components.",


### PR DESCRIPTION
This pull request adds a new entry to the list of component registries displayed on the homepage. The update introduces "Inspira UI" as an additional modern component registry for shadcn/ui components.

New registry added:

* Added an entry for "Inspira UI" with its name, description, and URL to the `entries` array in `apps/web/app/page.tsx`.