### PR TITLE
fix(web): links with missing utm source

### DIFF
--- a/apps/web/components/directory-list.tsx
+++ b/apps/web/components/directory-list.tsx
@@ -75,7 +75,7 @@ export function DirectoryList({ entries }: { entries: DirectoryEntry[] }) {
                 </CardDescription>
               </CardContent>
               <CardFooter className="px-4 pb-4 pt-0 bg-black">
-                <a href={entry.url} target="_blank" rel="noreferrer" className="text-xs text-neutral-300 leading-relaxed font-mono truncate hover:underline">
+                <a href={addUtmReference(entry.url)} target="_blank" rel="noreferrer" className="text-xs text-neutral-300 leading-relaxed font-mono truncate hover:underline">
                   {getHostname(entry.url)}
                 </a>
               </CardFooter>


### PR DESCRIPTION
This pull request makes a small update to the `DirectoryList` component to improve link tracking. The change ensures that all directory entry URLs have UTM parameters added before being rendered.

* Updated the anchor tag in `DirectoryList` to use the `addUtmReference` function on `entry.url`, ensuring that outbound links include UTM tracking parameters.