### PR TITLE
Add Extend UI registry

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -25,6 +25,11 @@ export const metadata: Metadata = {
 export default async function Home() {
   const entries: DirectoryEntry[] = [
     {
+      name: "Pure UI",
+      description: "Enhanced shadcn/ui components with advanced functionality and design patterns.",
+      url: "https://pure.ui.pub/"
+    },
+    {
       name: "shadcn/ui",
       description: "The official registry for shadcn/ui components.",
       url: "https://ui.shadcn.com/",

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -117,6 +117,12 @@ export default async function Home() {
       description: "Skiper UI - Un-common Components for shadcn/ui | Skiper UI",
       url: "https://skiper-ui.com/"
     }
+    ,
+    {
+      name: "Extend UI",
+      description: "A component registry and design system built for Tailwind + React. Components are distributed for use with shadcn.",
+      url: "https://www.extend-ui.com/"
+    }
   ];
   return (
     <main className="flex min-h-screen flex-col items-center justify-center py-20">

--- a/registries.json
+++ b/registries.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "Extend UI",
+    "description": "A component registry and design system built for Tailwind + React. Components are distributed for use with shadcn.",
+    "url": "https://www.extend-ui.com/",
+    "distribution": {
+      "method": "shadcn",
+      "install": "npx shadcn@latest https://www.extend-ui.com/{component}"
+    }
+  }
+]


### PR DESCRIPTION
This pull request adds new UI component registries to both the web app directory listing and the `registries.json` file, expanding the available resources for users. The most important changes are:

**Additions to UI registry listings:**

* Added "Pure UI" to the `entries` array in `apps/web/app/page.tsx`, including its description and external URL.
* Added "Extend UI" to the `entries` array in `apps/web/app/page.tsx`, with its description and external URL.

**Registry metadata updates:**

* Added a new entry for "Extend UI" in `registries.json`, specifying its name, description, URL, and distribution method for use with shadcn.