### PR TITLE
Add multiple new component libraries: Animate UI, AI Elements, Shadcn.IO, Dice UI, ElevenLabs UI, 8bitcn and pqoqubbw/icons

### DIFF
--- a/apps/web/public/registries.json
+++ b/apps/web/public/registries.json
@@ -94,9 +94,44 @@
     "description": "An open source collection of animated, interactive & fully customizable React components for building memorable websites.",
     "url": "https://reactbits.dev/"
   },
-    {
+  {
     "name": "WDS Shadcn Registry",
     "description": "A collection of accessible components that fit perfectly with Shadcn.",
     "url": "https://wds-shadcn-registry.netlify.app/"
+  },
+  {
+    "name": "Animate UI",
+    "description": "Fully animated, open-source component distribution built with React, TypeScript, Tailwind CSS, Motion, and Shadcn CLI.",
+    "url": "https://animate-ui.com/"
+  },
+  {
+    "name": "AI Elements",
+    "description": "A component library to help you build AI-native applications faster. It provides pre-built components like conversations, messages and more.",
+    "url": "https://ai-sdk.dev/elements/overview"
+  },
+  {
+    "name": "Shadcn.IO",
+    "description": "Essential UI components, advanced patterns, and AI integrations.",
+    "url": "https://shadcn.io/"
+  },
+  {
+    "name": "Dice UI",
+    "description": "Accessible shadcn/ui components built with React, TypeScript, and Tailwind CSS. Copy-paste ready, and customizable.",
+    "url": "https://www.diceui.com/"
+  },
+  {
+    "name": "ElevenLabs UI",
+    "description": "A collection of components designed for agent & audio applications, including orbs, waveforms, voice agents, audio players, and more.",
+    "url": "https://ui.elevenlabs.io/"
+  },
+  {
+    "name": "8bitcn",
+    "description": "A set of 8-bit styled components for shadcn/ui. Works with your favorite frameworks. Open Source. Open Code.",
+    "url": "https://www.8bitcn.com/"
+  },
+  {
+    "name": "pqoqubbw/icons",
+    "description": "An open-source (MIT License) collection of smooth animated icons for your projects. Built with motion and lucide",
+    "url": "https://icons.pqoqubbw.dev/"
   }
 ]


### PR DESCRIPTION
This PR adds multiple entries to the registries listed on `registries.json`.

**Added**: 
- `Animate UI`: Fully animated components
- `AI Elements`: A component library to help you build AI-native applications
- `Shadcn.IO`: Advanced components
- `Dice UI`: Accessible shadcn/ui components
- `ElevenLabs UI`: A collection of components designed for agent & audio AI applications
- `8bitcn`: 8-bit styled components
- `pqoqubbw/icons`: A collection of animated icons