### PR TITLE
feat: add algolia sitesearch

### DIFF
--- a/apps/web/public/registries.json
+++ b/apps/web/public/registries.json
@@ -40,7 +40,7 @@
     "url": "https://shadcnblocks.com"
   },
   {
-    "name": "Algolia Sitesearch",
+    "name": "Algolia SiteSearch",
     "description": "Opinionated search experiences for your website needs, powered by Algolia",
     "url": "https://sitesearch.algolia.com/"
   },


### PR DESCRIPTION
Hi, we would like to add sitesearch to the registry directory.
They are opinionated Algolia InstantSearch experience for your built for site search needs.

We are on the centralized `@shadcn` repo as `@algolia`.

Thanks