### PR TITLE
feat: add internal feedback widget

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,3 +4,6 @@ CRON_SECRET=             # Generate with: openssl rand -hex 32
 
 # Affiliates (set to false to disable all affiliate links)
 NEXT_PUBLIC_AFFILIATES_ENABLED=true
+
+# Feedback widget (internal dogfooding)
+NEXT_PUBLIC_FEEDBACK_ENABLED=

--- a/apps/web/app/api/feedback/route.ts
+++ b/apps/web/app/api/feedback/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { feedbackSchema, appendFeedback } from "@/lib/feedback";
+
+export async function POST(request: Request) {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    return NextResponse.json(
+      { error: "Feedback storage not configured" },
+      { status: 503 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const parsed = feedbackSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid feedback", details: parsed.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const id = await appendFeedback(parsed.data);
+    return NextResponse.json({ success: true, id });
+  } catch (error) {
+    console.error("[feedback] API error:", error);
+    return NextResponse.json(
+      { error: "Failed to save feedback" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,6 +4,7 @@ import { Analytics } from "@vercel/analytics/next"
 
 import "@workspace/ui/globals.css"
 import { Providers } from "@/components/providers"
+import { FeedbackWidget } from "@/components/feedback-widget"
 
 const dmSans = DM_Sans({
   variable: "--font-dm-sans",
@@ -49,6 +50,7 @@ export default function RootLayout({
         <Providers>
           {children}
         </Providers>
+        <FeedbackWidget />
         <Analytics />
       </body>
     </html>

--- a/apps/web/components/feedback-widget.tsx
+++ b/apps/web/components/feedback-widget.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@workspace/ui/components/button";
+import { cn } from "@workspace/ui/lib/utils";
+import { Bug, CircleHelp, Lightbulb, MessageSquare, X, type LucideIcon } from "lucide-react";
+import type { FeedbackType } from "@/lib/feedback";
+
+const FEEDBACK_TYPES: { value: FeedbackType; label: string; icon: LucideIcon }[] = [
+  { value: "bug", label: "Bug", icon: Bug },
+  { value: "confusing", label: "Confusing", icon: CircleHelp },
+  { value: "idea", label: "Idea", icon: Lightbulb },
+];
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+export function FeedbackWidget() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [type, setType] = useState<FeedbackType>("confusing");
+  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+
+  if (process.env.NEXT_PUBLIC_FEEDBACK_ENABLED !== "true") {
+    return null;
+  }
+
+  const toggle = useCallback(() => setIsOpen((o) => !o), []);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "." && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        toggle();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [toggle]);
+
+  useEffect(() => {
+    if (status === "success") {
+      const timer = setTimeout(() => {
+        setStatus("idle");
+        setIsOpen(false);
+      }, 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [status]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!message.trim()) return;
+
+    setStatus("submitting");
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type,
+          message: message.trim(),
+          url: window.location.href,
+          pathname: window.location.pathname,
+          userAgent: navigator.userAgent,
+          viewport: {
+            width: window.innerWidth,
+            height: window.innerHeight,
+          },
+        }),
+      });
+
+      if (!res.ok) throw new Error();
+
+      setMessage("");
+      setType("confusing");
+      setStatus("success");
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={toggle}
+        className="fixed bottom-4 right-4 z-50 flex h-10 w-10 items-center justify-center rounded-full border border-border bg-background shadow-lg transition-colors hover:bg-accent"
+        aria-label="Send feedback (Cmd+.)"
+        title="Send feedback (Cmd+.)"
+      >
+        <MessageSquare className="size-4" />
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 w-80 rounded-lg border border-border bg-background shadow-lg">
+      {status === "success" ? (
+        <div className="flex items-center justify-center gap-2 p-6 text-sm text-muted-foreground">
+          Sent!
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3 p-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-foreground">
+              Feedback
+            </span>
+            <button
+              type="button"
+              onClick={toggle}
+              className="text-muted-foreground hover:text-foreground"
+              aria-label="Close"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+
+          <div className="flex gap-1.5">
+            {FEEDBACK_TYPES.map((ft) => (
+              <Button
+                key={ft.value}
+                type="button"
+                variant={type === ft.value ? "default" : "secondary"}
+                size="sm"
+                onClick={() => setType(ft.value)}
+                className="flex-1"
+              >
+                <ft.icon /> {ft.label}
+              </Button>
+            ))}
+          </div>
+
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="What's on your mind?"
+            className="min-h-[100px] w-full resize-none rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            maxLength={2000}
+            autoFocus
+          />
+
+          {status === "error" && (
+            <p className="text-xs text-destructive">
+              Failed to send. Try again.
+            </p>
+          )}
+
+          <Button
+            type="submit"
+            size="sm"
+            disabled={!message.trim() || status === "submitting"}
+            className="w-full"
+          >
+            {status === "submitting" ? "Sending..." : "Send"}
+          </Button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/feedback.ts
+++ b/apps/web/lib/feedback.ts
@@ -1,0 +1,86 @@
+import { put } from "@vercel/blob";
+import { z } from "zod";
+
+export const feedbackTypes = ["bug", "confusing", "idea"] as const;
+export type FeedbackType = (typeof feedbackTypes)[number];
+
+export const feedbackSchema = z.object({
+  type: z.enum(feedbackTypes),
+  message: z.string().min(1).max(2000),
+  url: z.string().url(),
+  pathname: z.string(),
+  userAgent: z.string(),
+  viewport: z.object({
+    width: z.number(),
+    height: z.number(),
+  }),
+});
+
+export type FeedbackInput = z.infer<typeof feedbackSchema>;
+
+export interface FeedbackEntry extends FeedbackInput {
+  id: string;
+  timestamp: string;
+}
+
+function getBlobFilename(date: Date): string {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `feedback/${yyyy}-${mm}-${dd}.json`;
+}
+
+function getBlobPublicUrl(filename: string): string | null {
+  const blobToken = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!blobToken) return null;
+
+  const storeMatch = blobToken.match(/vercel_blob_rw_([^_]+)_/);
+  if (!storeMatch) return null;
+
+  return `https://${storeMatch[1]}.public.blob.vercel-storage.com/${filename}`;
+}
+
+async function readFeedbackBlob(filename: string): Promise<FeedbackEntry[]> {
+  const url = getBlobPublicUrl(filename);
+  if (!url) return [];
+
+  try {
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) return [];
+    return (await response.json()) as FeedbackEntry[];
+  } catch {
+    return [];
+  }
+}
+
+async function writeFeedbackBlob(
+  filename: string,
+  entries: FeedbackEntry[]
+): Promise<void> {
+  const blobToken = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!blobToken) return;
+
+  await put(filename, JSON.stringify(entries, null, 2), {
+    access: "public",
+    token: blobToken,
+    addRandomSuffix: false,
+    allowOverwrite: true,
+  });
+}
+
+export async function appendFeedback(input: FeedbackInput): Promise<string> {
+  const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+  const entry: FeedbackEntry = {
+    ...input,
+    id,
+    timestamp: new Date().toISOString(),
+  };
+
+  const filename = getBlobFilename(new Date());
+  const existing = await readFeedbackBlob(filename);
+  existing.push(entry);
+  await writeFeedbackBlob(filename, existing);
+
+  console.log(`[feedback] Saved entry ${id} to ${filename}`);
+  return id;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,8 @@
     "react-dom": "^19.2.3",
     "react-resizable-panels": "^2.1.7",
     "shadcn": "^3.7.0",
-    "shiki": "^1.0.0"
+    "shiki": "^1.0.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/node": "^20.19.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       shiki:
         specifier: ^1.0.0
         version: 1.29.2
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
     devDependencies:
       '@types/node':
         specifier: ^20.19.26


### PR DESCRIPTION
Adds the first write path to the platform — a floating feedback widget (FAB) that captures bug reports, confusing UX, and ideas while browsing. 

Stores entries in Vercel Blob (per-day JSON files), feature-flagged via `NEXT_PUBLIC_FEEDBACK_ENABLED`. 

Keyboard shortcut: `Cmd + .`