### PR TITLE
Add 21st.dev Agent Elements

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -357,6 +357,14 @@
       "registry_url": "https://termcn.vercel.app/r/registry.json",
       "github_url": "https://github.com/Aniket-508/termcn",
       "github_profile": "https://github.com/Aniket-508.png"
+    },
+    {
+      "name": "21st.dev Agent Elements",
+      "description": "Open-source registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan), clarifying questions, input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK.",
+      "url": "https://agent-elements.21st.dev",
+      "registry_url": "https://agent-elements.21st.dev/r/index.json",
+      "github_url": "https://github.com/21st-dev/agent-elements",
+      "github_profile": "https://github.com/21st-dev.png"
     }
   ]
 }


### PR DESCRIPTION
Adds **21st.dev Agent Elements** to the directory.

Open-source shadcn registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan, MCP, Thinking), clarifying questions, composable input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK.

- Site: https://agent-elements.21st.dev
- Registry: https://agent-elements.21st.dev/r/index.json
- Repo: https://github.com/21st-dev/agent-elements
- Install: `npx shadcn@latest add https://agent-elements.21st.dev/r/agent-chat.json`