### PR TITLE
fix: redirect index-less partner registries instead of 404

### DIFF
--- a/apps/web/app/(app)/[owner]/[repo]/page.tsx
+++ b/apps/web/app/(app)/[owner]/[repo]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation"
+import { notFound, redirect } from "next/navigation"
 import { readFile } from "node:fs/promises"
 import { join } from "node:path"
 import type { Metadata } from "next"
@@ -103,6 +103,20 @@ export async function generateStaticParams() {
     .filter(Boolean) as { owner: string; repo: string }[]
 }
 
+// Some partner registries (e.g. shadcn/studio) don't publish an aggregate
+// registry.json index — they only expose per-item namespaced files. We can't
+// build an overview without that index, so we send visitors to the registry's
+// own site (tagged with ?ref=registrydirectory) instead of showing a 404.
+function externalRegistryUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl)
+    url.searchParams.set("ref", "registrydirectory")
+    return url.toString()
+  } catch {
+    return rawUrl
+  }
+}
+
 export type SemanticCategory = { name: string; count: number }
 
 function extractSemanticCategories(items: RegistryItem[]): SemanticCategory[] {
@@ -133,19 +147,17 @@ export default async function RegistryOverviewPage({
 
   const registryData = await fetchRegistryData(registry)
 
-  if (!registryData) {
-    notFound()
-  }
-
-  if (!registryData.items || !Array.isArray(registryData.items)) {
-    notFound()
+  // Registry is known but exposes no usable aggregate index — redirect to the
+  // partner's own site rather than dead-ending visitors on a 404.
+  if (!registryData || !registryData.items || !Array.isArray(registryData.items)) {
+    redirect(externalRegistryUrl(registry.url))
   }
 
   // Group items by type
   const categoriesMap = groupItemsByCategory(registryData.items)
 
   if (categoriesMap.size === 0) {
-    notFound()
+    redirect(externalRegistryUrl(registry.url))
   }
 
   // Fetch GitHub stats, semantic categories, and affiliates in parallel


### PR DESCRIPTION
## Problem

`/[owner]/[repo]` overview pages returned a hard **404** for partner registries that don't publish an aggregate `registry.json` index.

Concrete case (critical — partner): **`/shadcnstudio/shadcn-studio`**. shadcn/studio uses shadcn CLI v4 **namespaced registries** that only expose per-item files (`/r/components/{style}/{name}.json`, `/r/blocks/...`, `/r/themes/...`). The configured `registry_url` (`https://shadcnstudio.com/r/registry.json`) returns **404 HTML**, so `fetchRegistryData()` returned `null` and the page dead-ended on `notFound()`.

The home card still rendered (graceful degradation), so the registry was *visible in the listing but broke on click* — the worst case for a partner.

## Fix

When a registry **exists in the directory but has no usable aggregate index**, redirect (307) to the registry's own site tagged with `?ref=registrydirectory`, instead of showing a 404.

- Derived generically from `registry.url` (not hardcoded), so any future index-less partner is covered automatically.
- For shadcn/studio this yields `https://shadcnstudio.com/?ref=registrydirectory`.
- Unknown owners/repos still `notFound()` (legit 404).
- Registries with a valid index render unchanged.

## Verification

| Route | Before | After |
|---|---|---|
| `/shadcnstudio/shadcn-studio` (partner, no index) | 404 | **307 → `https://shadcnstudio.com/?ref=registrydirectory`** |
| `/shadcn-ui/ui` (valid index) | 200 | 200 (unchanged) |
| `/nonexistent/nope` (unknown) | 404 | 404 (unchanged) |

- `pnpm typecheck` ✅
- Verified against local dev server ✅

## Follow-ups (not in this PR)

- Reach out to shadcn/studio to publish a standard aggregate `registry.json` so their components render natively instead of redirecting.
- Data-quality: at least one `directory.json` entry has `github_url: null` — worth a separate cleanup.