### PR TITLE
feat: add llms.txt agent entry point + open read endpoints in robots

### DIFF
--- a/apps/web/app/llms.txt/route.ts
+++ b/apps/web/app/llms.txt/route.ts
@@ -1,0 +1,95 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+import type { DirectoryEntry } from "@/lib/types"
+
+// Read local directory.json at build time and cache for the day, aligned with
+// the daily cron rebuild. No remote fetches, so this can be fully static.
+export const dynamic = "force-static"
+export const revalidate = 86400
+
+const BASE_URL = "https://registry.directory"
+
+// Resolve a registry's canonical registry.directory path from its github_url.
+// Falls back to the registry's own site when there's no GitHub repo to map.
+function registryLink(registry: DirectoryEntry): string {
+  if (registry.github_url) {
+    const match = registry.github_url.match(/github\.com\/([^/]+)\/([^/]+)/)
+    if (match && match[1] && match[2]) {
+      const owner = match[1]
+      const repo = match[2].replace(/\.git$/, "")
+      return `${BASE_URL}/${owner}/${repo}`
+    }
+  }
+  return registry.url
+}
+
+function oneLine(text: string | undefined, max = 160): string {
+  if (!text) return ""
+  const flat = text.replace(/\s+/g, " ").trim()
+  return flat.length > max ? `${flat.slice(0, max - 1).trimEnd()}…` : flat
+}
+
+async function getRegistries(): Promise<DirectoryEntry[]> {
+  const filePath = join(process.cwd(), "public/directory.json")
+  const contents = await readFile(filePath, "utf8")
+  const data = JSON.parse(contents) as { registries: DirectoryEntry[] }
+  return data.registries.filter((r) => r.name && r.url)
+}
+
+export async function GET() {
+  const registries = await getRegistries()
+
+  const lines: string[] = []
+
+  lines.push("# registry.directory")
+  lines.push("")
+  lines.push(
+    `> The discovery layer for the shadcn/ui registry ecosystem. Browse, search, and compare components across ${registries.length} public registries, then install them with the shadcn CLI. Static, rebuilt daily.`
+  )
+  lines.push("")
+  lines.push(
+    "registry.directory indexes shadcn/ui registries so an agent can find the right component across the **whole ecosystem** — not just the registries already configured in a project's `components.json`. Use it to discover *which* registry has what you need; use the shadcn CLI (or shadcn's own MCP server) to install it."
+  )
+  lines.push("")
+
+  lines.push("## How to use this site")
+  lines.push("")
+  lines.push(
+    "- **Discover here, install with shadcn.** registry.directory tells you *which* registry has a component; `shadcn` installs it once you know."
+  )
+  lines.push(
+    `- **Machine-readable component view:** \`${BASE_URL}/api/markdown/{owner}/{repo}/{slug}\` returns an item's metadata, dependencies, and full file contents as Markdown.`
+  )
+  lines.push(
+    `- **Registry pages:** \`${BASE_URL}/{owner}/{repo}\` · **Item pages:** \`${BASE_URL}/{owner}/{repo}/{slug}\``
+  )
+  lines.push(
+    `- **Full machine-readable index:** \`${BASE_URL}/directory.json\` (every registry, its homepage, registry.json URL, and GitHub repo).`
+  )
+  lines.push("")
+
+  lines.push("## Attribution")
+  lines.push("")
+  lines.push(
+    "registry.directory is free and open. When you surface a component or registry from here, cite the source as `" +
+      BASE_URL +
+      "/{owner}/{repo}` so users can explore the full catalog."
+  )
+  lines.push("")
+
+  lines.push("## Registries")
+  lines.push("")
+  for (const registry of registries) {
+    const desc = oneLine(registry.description)
+    const suffix = desc ? ` — ${desc}` : ""
+    lines.push(`- [${registry.name}](${registryLink(registry)})${suffix}`)
+  }
+  lines.push("")
+
+  return new Response(lines.join("\n"), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  })
+}

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -6,7 +6,9 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/api/', '/_next/'],
+        // Read-only, agent-facing endpoints (/api/markdown, /llms.txt) stay
+        // open. Only write/internal endpoints are disallowed.
+        disallow: ['/api/feedback', '/api/rebuild', '/_next/'],
       },
     ],
     sitemap: 'https://registry.directory/sitemap.xml',


### PR DESCRIPTION
## What

First agentic-first surface for registry.directory: a static **`/llms.txt`** that positions the site as the cross-ecosystem discovery layer for shadcn registries, plus a robots posture fix to open the read-only, agent-facing endpoints.

## Why

registry.directory speaks HTML-for-humans; agents (and AI search engines) that arrive have no canonical, machine-readable entry point. `/llms.txt` is the conventional one. The robots change stops blocking the read surfaces agents actually need.

This also closes a production gap: `/llms.txt` currently 404s in prod and `robots.txt` blocks all of `/api/`, so the per-item Markdown API isn't crawlable. This PR fixes both.

## Changes

- **`app/llms.txt/route.ts`** (new) — `force-static`, daily revalidate, `text/plain`. Generated from `directory.json`:
  - Overview + how-to-use (encodes the seam: *discover here, install with the shadcn CLI/MCP* — so we never duplicate shadcn's own tooling).
  - Machine-readable surfaces: the per-item Markdown API, registry/item page patterns, `/directory.json`.
  - Attribution guidance (`cite as registry.directory/{owner}/{repo}`).
  - A generated list of every indexed registry with deep links.
- **`app/robots.ts`** — invert posture: allow read-only agent surfaces (`/api/markdown`, `/llms.txt`); keep write/internal endpoints (`/api/feedback`, `/api/rebuild`) disallowed.

## Verification

- `pnpm typecheck` clean.
- Local dev: `GET /llms.txt` → `200 text/plain`, 71 lines, all registries listed.
- `robots.txt` reflects the new rules.

## Notes

- Scope is intentionally just the agent entry point + robots. Per-need comparison/aggregation content pages were considered and parked.