### PR TITLE
feat: add Dominik UI registry

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -384,8 +384,8 @@
     },
     {
       "name": "Dominik UI",
-      "description": "An open-source shadcn/ui registry of animated React components: expandable icon tabs with a sliding active pill and a multi-variant braille loading indicator.",
-      "url": "https://dominikkoch.dev/registry",
+      "description": "Opinionated components and tools for building modern AI interfaces.",
+      "url": "https://dominikkoch.dev/ui",
       "registry_url": "https://dominikkoch.dev/r/registry.json",
       "github_url": "https://github.com/mezotv/portfolio",
       "github_profile": "https://github.com/mezotv.png"

--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -381,6 +381,14 @@
       "registry_url": "https://ui.trophy.so/r/registry.json",
       "github_url": "https://github.com/trophyso/ui",
       "github_profile": "https://github.com/trophyso.png"
+    },
+    {
+      "name": "Dominik UI",
+      "description": "An open-source shadcn/ui registry of animated React components: expandable icon tabs with a sliding active pill and a multi-variant braille loading indicator.",
+      "url": "https://dominikkoch.dev/registry",
+      "registry_url": "https://dominikkoch.dev/r/registry.json",
+      "github_url": "https://github.com/mezotv/portfolio",
+      "github_profile": "https://github.com/mezotv.png"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds Dominik UI to the registry directory.

- Homepage: https://dominikkoch.dev/registry
- Registry: https://dominikkoch.dev/r/registry.json
- GitHub: https://github.com/mezotv/portfolio

Dominik UI is an open-source shadcn/ui registry of animated React components (expandable icon tabs and a multi-variant braille loading indicator).

## Checklist

- [x] `registry.json` is publicly accessible
- [x] Component JSON files resolve at documented paths
- [x] Registry works with shadcn CLI