### PR TITLE
feat: add Shuip to the directory

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -56,6 +56,14 @@
       "github_profile": "https://github.com/magicuidesign.png"
     },
     {
+      "name": "Shuip",
+      "description": "Ready-to-use React components, React-hook-form, Tanstack-form fields and blocks (kanban, datatables) to help you ship your projects faster by eliminating the repetitive work of building user interfaces.",
+      "url": "https://shuip.plvo.dev/docs",
+      "registry_url": "https://shuip.plvo.dev/r/registry.json",
+      "github_url": "https://github.com/plvo/shuip",
+      "github_profile": "https://github.com/plvo.png"
+    },
+    {
       "name": "Shadcnship",
       "description": "Production-ready shadcn registry for SaaS apps. UI Blocks and Connected Blocks with Supabase auth, Stripe payments, and Resend emails already integrated.",
       "url": "https://shadcnship.com/",


### PR DESCRIPTION
## Summary

Adds agentcn to the registry directory.

- Homepage: https://shuip.plvo.dev/docs
- Registry: https://shuip.plvo.dev/r/registry.json
- GitHub: https://github.com/plvo/shuip

## Checklist

- [x] `registry.json` is publicly accessible
- [x] Component JSON files resolve at documented paths
- [x] Registry works with shadcn CLI