### PR TITLE
feat: add Payload Components registry

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -381,6 +381,14 @@
       "registry_url": "https://ui.trophy.so/r/registry.json",
       "github_url": "https://github.com/trophyso/ui",
       "github_profile": "https://github.com/trophyso.png"
+    },
+    {
+      "name": "Payload Components",
+      "description": "MIT registry of typed Payload CMS blocks for Payload v3 + Next.js. Each block installs as reviewable source; the companion CLI also wires collection config, RenderBlocks, types, and the admin import map.",
+      "url": "https://www.payload-components.xyz/",
+      "registry_url": "https://www.payload-components.xyz/r/registry.json",
+      "github_url": "https://github.com/Ducksss/payload-components",
+      "github_profile": "https://github.com/Ducksss.png"
     }
   ]
 }


### PR DESCRIPTION
Adds Payload Components to the registry.directory public index.

Payload Components is an open-source MIT registry of typed Payload CMS blocks for Payload v3 + Next.js. Each block installs as reviewable source, and the companion CLI wires the Payload collection config, renderer map, generated types, and admin import map.

Details:
- Homepage: https://www.payload-components.xyz/
- Registry index: https://www.payload-components.xyz/r/registry.json
- GitHub: https://github.com/Ducksss/payload-components

Validation:
- `jq empty apps/web/public/directory.json`
- `pnpm exec prettier --check apps/web/public/directory.json`
- custom schema checks for required fields, valid URLs, duplicate names, and the Payload Components entry
- verified `https://www.payload-components.xyz/r/registry.json` returns 200

Note: `pnpm lint` currently fails before this change is evaluated because `packages/ui` runs `eslint` but the workspace install does not expose an `eslint` binary there. `pnpm --filter web build` compiled and type-checked, then was stopped during full static generation after several minutes of repeated third-party fetch/cache retries against existing registries, mostly `https://platejs.org/r/registry.json` over the Next data cache size limit.
