### PR TITLE
PinZheng(config): add Payload Components registry

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -381,6 +381,14 @@
       "registry_url": "https://ui.trophy.so/r/registry.json",
       "github_url": "https://github.com/trophyso/ui",
       "github_profile": "https://github.com/trophyso.png"
+    },
+    {
+      "name": "Payload Components",
+      "description": "MIT registry and CLI for typed Payload CMS blocks in Payload v3 + Next.js projects. Blocks install as reviewable source with Payload wiring for collection config, render maps, types, and the admin import map.",
+      "url": "https://www.payload-components.xyz",
+      "registry_url": "https://www.payload-components.xyz/r/registry.json",
+      "github_url": "https://github.com/Ducksss/payload-components",
+      "github_profile": "https://github.com/Ducksss.png"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds Payload Components to registry.directory.

Payload Components is an MIT registry and CLI for typed Payload CMS blocks in Payload v3 + Next.js projects. Blocks install as reviewable source and the companion CLI handles Payload wiring for collection config, render maps, generated types, and the admin import map.

## Links

- Website: https://www.payload-components.xyz
- Registry: https://www.payload-components.xyz/r/registry.json
- GitHub: https://github.com/Ducksss/payload-components
- Example item: https://www.payload-components.xyz/r/hero-basic.json

## Validation

- Parsed `apps/web/public/directory.json` with Node
- `git diff --check`
- `HEAD https://www.payload-components.xyz/r/registry.json` returns 200
- `HEAD https://www.payload-components.xyz/r/hero-basic.json` returns 200
