### PR TITLE
feat: replace Components/Tools tabs with registry sort (Popular · Stars · Recently active)

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -59,6 +59,10 @@ async function getRegistries(): Promise<DirectoryEntry[]> {
   }
 }
 
+// Tools are benched — they are no longer rendered on the home page, but the
+// curated data is preserved in public/tools.json. This loader is intentionally
+// kept so bringing Tools back is a one-line change in Home().
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function getTools(): Promise<DirectoryEntry[]> {
   try {
     const filePath = join(process.cwd(), "public/tools.json");
@@ -83,7 +87,6 @@ async function getTools(): Promise<DirectoryEntry[]> {
 
 export default async function Home() {
   const components = await getRegistries();
-  const tools = await getTools();
   const [stats, githubStats, items, affiliates] = await Promise.all([
     fetchAllRegistryStats(components),
     fetchAllGitHubStats(components),
@@ -130,7 +133,7 @@ export default async function Home() {
       </p>
 
       <Suspense fallback={<DirectoryTabsSkeleton />}>
-        <DirectoryTabs components={components} tools={tools} stats={stats} githubStats={githubStats} items={items} affiliates={affiliates} />
+        <DirectoryTabs components={components} stats={stats} githubStats={githubStats} items={items} affiliates={affiliates} />
       </Suspense>
 
       <AffiliateDisclosure />

--- a/apps/web/components/directory-tabs-skeleton.tsx
+++ b/apps/web/components/directory-tabs-skeleton.tsx
@@ -4,8 +4,9 @@ export function DirectoryTabsSkeleton() {
       {/* Tabs bar + search bar */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-6 mb-4 md:mb-6">
         <div className="inline-flex items-center gap-8">
-          <div className="h-5 w-20 bg-surface-elevated rounded-sm" />
+          <div className="h-5 w-16 bg-surface-elevated rounded-sm" />
           <div className="h-5 w-12 bg-surface-elevated rounded-sm" />
+          <div className="h-5 w-28 bg-surface-elevated rounded-sm" />
         </div>
         <div className="flex-1 w-full sm:w-auto">
           <div className="h-10 w-full bg-surface border border-border rounded-md" />

--- a/apps/web/components/directory-tabs.tsx
+++ b/apps/web/components/directory-tabs.tsx
@@ -10,16 +10,61 @@ import type { DirectoryEntry, GitHubStats, RegistryStats, AffiliateConfig } from
 import type { IndexedItem } from '@/lib/items-index';
 import { searchItems } from '@/lib/search-utils';
 
+type SortMode = 'popular' | 'stars' | 'recently-active';
+
+type GitHubStatsRecord = Record<string, Omit<GitHubStats, 'fetchedAt'>>;
+
+/**
+ * Reorder registries by the active sort. The card set is identical across
+ * sorts — only the order changes — so all of this is a pure client-side
+ * reordering of data already in props (no fetch, no infra).
+ *
+ * - popular: curated order as-is (the order in directory.json)
+ * - stars: GitHub stars, descending
+ * - recently-active: last commit (pushed_at), descending
+ *
+ * Entries without GitHub data sink to the bottom; ties fall back to the
+ * curated order via a stable index tiebreak.
+ */
+function sortRegistries(
+  entries: DirectoryEntry[],
+  mode: SortMode,
+  githubStats: GitHubStatsRecord
+): DirectoryEntry[] {
+  if (mode === 'popular') return entries;
+
+  const statOf = (entry: DirectoryEntry) =>
+    entry.github_url ? githubStats[entry.github_url] : undefined;
+
+  return entries
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => {
+      let av: number;
+      let bv: number;
+      if (mode === 'stars') {
+        av = statOf(a.entry)?.stars ?? -1;
+        bv = statOf(b.entry)?.stars ?? -1;
+      } else {
+        const at = statOf(a.entry)?.lastCommit;
+        const bt = statOf(b.entry)?.lastCommit;
+        av = at ? Date.parse(at) : -Infinity;
+        bv = bt ? Date.parse(bt) : -Infinity;
+      }
+      if (bv !== av) return bv - av;
+      return a.index - b.index; // stable: preserve curated order among ties
+    })
+    .map(({ entry }) => entry);
+}
+
 interface DirectoryTabsProps {
   components: DirectoryEntry[];
-  tools: DirectoryEntry[];
   stats: Record<string, RegistryStats>;
-  githubStats: Record<string, Omit<GitHubStats, 'fetchedAt'>>;
+  githubStats: GitHubStatsRecord;
   items: IndexedItem[];
   affiliates: Record<string, AffiliateConfig>;
 }
 
-export function DirectoryTabs({ components, tools, stats, githubStats, items, affiliates }: DirectoryTabsProps) {
+export function DirectoryTabs({ components, stats, githubStats, items, affiliates }: DirectoryTabsProps) {
   const analytics = useAnalytics();
   const { activeTab, setActiveTab, searchTerm, setSearchTerm } = useUrlState();
   const deferredSearchTerm = useDeferredValue(searchTerm);
@@ -27,22 +72,18 @@ export function DirectoryTabs({ components, tools, stats, githubStats, items, af
   const filteredComponents = useMemo(() => {
     if (!searchTerm) return components;
     const term = searchTerm.toLowerCase();
-    return components.filter(entry => 
+    return components.filter(entry =>
       entry.name.toLowerCase().includes(term) ||
       entry.description.toLowerCase().includes(term) ||
       entry.url.toLowerCase().includes(term)
     );
   }, [components, searchTerm]);
 
-  const filteredTools = useMemo(() => {
-    if (!searchTerm) return tools;
-    const term = searchTerm.toLowerCase();
-    return tools.filter(entry => 
-      entry.name.toLowerCase().includes(term) ||
-      entry.description.toLowerCase().includes(term) ||
-      entry.url.toLowerCase().includes(term)
-    );
-  }, [tools, searchTerm]);
+  // Sort the (filtered) registries by the active tab. Search filters, sort orders.
+  const sortedComponents = useMemo(
+    () => sortRegistries(filteredComponents, activeTab as SortMode, githubStats),
+    [filteredComponents, activeTab, githubStats]
+  );
 
   const filteredItems = useMemo(() => {
     if (!deferredSearchTerm) return [];
@@ -50,16 +91,15 @@ export function DirectoryTabs({ components, tools, stats, githubStats, items, af
   }, [items, deferredSearchTerm]);
 
   // Track search performed (debounced via hook)
-  const activeRegistryResults = activeTab === 'components' ? filteredComponents : filteredTools;
   useEffect(() => {
     if (!deferredSearchTerm) return;
     analytics.trackSearchPerformed({
       search_query: deferredSearchTerm,
-      active_tab: activeTab as "components" | "tools",
-      registry_results_count: activeRegistryResults.length,
-      item_results_count: activeTab === 'components' ? filteredItems.length : 0,
+      active_tab: activeTab as SortMode,
+      registry_results_count: sortedComponents.length,
+      item_results_count: filteredItems.length,
     });
-  }, [deferredSearchTerm, activeTab, activeRegistryResults.length, filteredItems.length, analytics]);
+  }, [deferredSearchTerm, activeTab, sortedComponents.length, filteredItems.length, analytics]);
 
   const handleResultClick = useCallback((result: { result_type: SearchResultType; result_name: string; result_position: number }) => {
     if (!searchTerm) return;
@@ -69,53 +109,38 @@ export function DirectoryTabs({ components, tools, stats, githubStats, items, af
     });
   }, [searchTerm, analytics]);
 
-  const addComponentUrl = 'https://github.com/rbadillap/registry.directory';
-  const addToolUrl = 'https://github.com/rbadillap/registry.directory';
+  const addRegistryUrl = 'https://github.com/rbadillap/registry.directory';
 
   return (
     <div className="w-full max-w-7xl mx-auto px-4">
-      <Tabs defaultValue="components" value={activeTab} onValueChange={setActiveTab}>
+      <Tabs defaultValue="popular" value={activeTab} onValueChange={setActiveTab}>
         <div className="sticky top-0 z-10 bg-background flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-6 mb-4 md:mb-6 py-3">
           <TabsList>
-            <TabsTrigger value="components">Registries</TabsTrigger>
-            <TabsTrigger value="tools">Tools</TabsTrigger>
+            <TabsTrigger value="popular">Popular</TabsTrigger>
+            <TabsTrigger value="stars">Stars</TabsTrigger>
+            <TabsTrigger value="recently-active">Recently active</TabsTrigger>
           </TabsList>
 
           <div className="flex-1 w-full sm:w-auto">
-            <SearchBar 
-              value={searchTerm} 
+            <SearchBar
+              value={searchTerm}
               onChange={setSearchTerm}
-              placeholder={
-                activeTab === 'components' 
-                  ? "Search registries and components..."
-                  : "Search tools..."
-              }
+              placeholder="Search registries and components..."
             />
           </div>
         </div>
 
-        <TabsContent value="components">
+        <TabsContent value={activeTab}>
           <DirectoryList
-            entries={filteredComponents}
+            entries={sortedComponents}
             searchTerm={searchTerm}
-            addCardUrl={addComponentUrl}
+            addCardUrl={addRegistryUrl}
             addCardLabel="Add your Registry"
             showViewButton={true}
             stats={stats}
             githubStats={githubStats}
             affiliates={affiliates}
-            itemResults={activeTab === 'components' ? filteredItems : []}
-            onResultClick={handleResultClick}
-          />
-        </TabsContent>
-
-        <TabsContent value="tools">
-          <DirectoryList
-            entries={filteredTools}
-            searchTerm={searchTerm}
-            addCardUrl={addToolUrl}
-            addCardLabel="Add your Tool"
-            showViewButton={false}
+            itemResults={filteredItems}
             onResultClick={handleResultClick}
           />
         </TabsContent>

--- a/apps/web/hooks/use-url-state.ts
+++ b/apps/web/hooks/use-url-state.ts
@@ -3,8 +3,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 
-const DEFAULT_TAB = 'components';
-const VALID_TABS = ['components', 'tools'] as const;
+const DEFAULT_TAB = 'popular';
+const VALID_TABS = ['popular', 'stars', 'recently-active'] as const;
 type TabValue = (typeof VALID_TABS)[number];
 
 function isValidTab(value: string | null): value is TabValue {

--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -98,7 +98,7 @@ export interface RegistryVisitProperties {
 }
 
 export type SearchResultType = "registry" | "item";
-export type HomeTab = "components" | "tools";
+export type HomeTab = "popular" | "stars" | "recently-active";
 
 export interface SearchPerformedProperties {
   search_query: string;


### PR DESCRIPTION
## What

Replaces the home page's `Registries · Tools` tabs with three **sort views** over the registries:

- **Popular** — the curated `directory.json` order (loads first, no "default" label shown to visitors)
- **Stars** — GitHub stars, descending
- **Recently active** — last commit (`pushed_at`), descending

## Why

The **Tools** tab saw little engagement, while the trend is clearly toward component registries. Rather than keep underused real estate, we repurpose that space into sorting — the standard discovery vocabulary for directories.

On data quality, the three sorts are deliberate:
- **Popular** is endogenous (our own ordering drives the visit distribution), so it needs no analytics infra — it *is* the curated order, validated by visits.
- **Stars** is the non-circular escape hatch: it lets a high-quality newcomer actually surface, preventing the directory from ossifying behind a feedback loop.
- **Recently active** = last commit (not "recently added", which we don't track) — a real signal of which registries are alive vs abandoned.

A genuine "Most visited / Trending" sort (post-click engagement: code copied, items explored, session depth — far less position-confounded than raw clicks) is deferred to Phase 2, where it would justify owned counters.

## How

Pure **client-side reordering** of data already threaded as props (`stars`, `lastCommit`) — **no new fetch, no new infrastructure**. Entries without GitHub data sink to the bottom; ties fall back to the curated order via a stable index tiebreak.

## Tools are benched, not removed

- `public/tools.json` is preserved untouched (the curated data is the irreplaceable part).
- The `getTools()` loader is intentionally kept (with an eslint-disable + comment) so re-enabling is a one-line change in `Home()`.

## URL / analytics

- `?tab` vocabulary: `popular | stars | recently-active`. `popular` keeps the URL clean (no param).
- Old `?tab=tools` / `?tab=components` links soft-redirect to Popular (invalid → default fallback).
- `HomeTab` analytics type updated to the three sort modes.

## Verification

- `pnpm typecheck` clean, `pnpm lint` no new warnings
- Home renders 200, all three triggers present, no Tools trigger, no error boundary
- Sort, deep links (`?tab=stars`, `?tab=recently-active`), search composition, and old-link fallback all verified locally
