### PR TITLE
Add ShadcnStore registry to directory

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -421,6 +421,14 @@
       "registry_url": "https://evex.sh/r/registry.json",
       "github_url": "https://github.com/TommyBez/evex",
       "github_profile": "https://github.com/TommyBez.png"
+    },
+    {
+      "name": "ShadcnStore",
+      "description": "A growing collection of shadcn/ui components, blocks, and templates for building modern web apps.",
+      "url": "https://shadcnstore.com/",
+      "registry_url": "https://shadcnstore.com/r/registry.json",
+      "github_url": "https://github.com/shadcnstore/shadcn-dashboard-landing-template",
+      "github_profile": "https://github.com/shadcnstore.png"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds [ShadcnStore](https://shadcnstore.com/)'s shadcn/ui registry to the registry directory.

- Homepage: https://shadcnstore.com/
- Registry: https://shadcnstore.com/r/registry.json
- GitHub: https://github.com/shadcnstore/shadcn-dashboard-landing-template

## Required Checklist

- [x] `registry.json` is publicly accessible
- [x] Component JSON files resolve at documented paths
- [x] Registry works with shadcn CLI