### PR TITLE
Add LocalMode registry

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -429,6 +429,14 @@
       "registry_url": "https://shadcnstore.com/r/registry.json",
       "github_url": "https://github.com/shadcnstore/shadcn-dashboard-landing-template",
       "github_profile": "https://github.com/shadcnstore.png"
+    },
+    {
+      "name": "LocalMode",
+      "description": "Local-first AI UI registry: copy-owned primitives and composed blocks (chat, RAG, transcription, CLIP search) that run entirely in the browser. No servers, no API keys.",
+      "url": "https://localmode.ai/",
+      "registry_url": "https://localmode.ai/r/registry.json",
+      "github_url": "https://github.com/LocalMode-AI/LocalMode",
+      "github_profile": "https://github.com/LocalMode-AI.png"
     }
   ]
 }


### PR DESCRIPTION
This PR adds **LocalMode** to the registry directory.

LocalMode is an open-source (MIT) shadcn registry of local-first AI UI: copy-owned primitives and composed blocks (chat, RAG, transcription, CLIP image search) that run entirely in the browser, with no servers or API keys. Installable with the shadcn CLI.

- Registry index: https://localmode.ai/r/registry.json (public, 147 items)
- Site: https://localmode.ai
- Repo: https://github.com/LocalMode-AI/LocalMode

Added to the bottom of the `registries` array in `apps/web/public/directory.json` per the contribution steps.
