### PR TITLE
feat: add Unlumen UI registry

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -437,6 +437,14 @@
       "registry_url": "https://localmode.ai/r/registry.json",
       "github_url": "https://github.com/LocalMode-AI/LocalMode",
       "github_profile": "https://github.com/LocalMode-AI.png"
+    },
+    {
+      "name": "Unlumen UI primitives",
+      "description": "Polished primitives(open source) and components for React and shadcn, shaped with thoughtful motion.",
+      "url": "https://ui.unlumen.com",
+      "registry_url": "https://unlumen-ui-docs.vercel.app/docs/r/registry.json",
+      "github_url": "https://github.com/leovvx/unlumen-ui-docs",
+      "github_profile": "https://github.com/Unlumen-lgtm.png"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add the Unlumen UI open-source registry to the directory.
- Link its public documentation, public shadcn registry, GitHub repository, and profile image.

## Validation

- `pnpm --filter web typecheck`
- Validated `apps/web/public/directory.json` as JSON.
- Confirmed the public registry catalog and all 60 listed item endpoints are accessible.
