### PR TITLE
Add AI Canvas registry

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -453,6 +453,14 @@
       "registry_url": "https://uiable.com/r/registry.json",
       "github_url": "https://github.com/codedthemes/uiable",
       "github_profile": "https://github.com/codedthemes.png"
+    },
+    {
+      "name": "AI Canvas",
+      "description": "Open-source animated React and Tailwind components, blocks, and design systems, installable via the shadcn CLI.",
+      "url": "https://aicanvas.me/",
+      "registry_url": "https://aicanvas.me/r/registry.json",
+      "github_url": "https://github.com/uiNerd16/aicanvas",
+      "github_profile": "https://github.com/uiNerd16.png"
     }
   ]
 }


### PR DESCRIPTION
Adds **AI Canvas** to the directory.

AI Canvas is an open-source (MIT) shadcn-compatible registry of animated React and Tailwind components, blocks, design systems, and templates.

- Site: https://aicanvas.me
- Registry: https://aicanvas.me/r/registry.json (public, valid shadcn schema)
- GitHub: https://github.com/uiNerd16/aicanvas
- Also listed in the official shadcn registry directory

Install: `npx shadcn@latest add @aicanvas/<component>`

Thanks!