### PR TITLE
Add AI Canvas registry

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -453,6 +453,14 @@
       "registry_url": "https://uiable.com/r/registry.json",
       "github_url": "https://github.com/codedthemes/uiable",
       "github_profile": "https://github.com/codedthemes.png"
+    },
+    {
+      "name": "AI Canvas",
+      "description": "Open-source animated React and Tailwind components, blocks, and design systems, installable via the shadcn CLI.",
+      "url": "https://aicanvas.me/",
+      "registry_url": "https://aicanvas.me/r/registry.json",
+      "github_url": "https://github.com/uiNerd16/aicanvas",
+      "github_profile": "https://github.com/uiNerd16.png"
     }
   ]
 }


### PR DESCRIPTION
Adds **AI Canvas** to the directory. This is a resubmission of #104, after fixing the three things raised in that review.

AI Canvas is an open-source (MIT) shadcn-compatible registry of animated React and Tailwind components, blocks, design systems, and templates.

- Site: https://aicanvas.me
- Registry: https://aicanvas.me/r/registry.json (public, valid shadcn schema)
- GitHub: https://github.com/uiNerd16/aicanvas
- Install: `npx shadcn@latest add @aicanvas/<component>`

## What changed since #104

**Gating is now declared in the index.** I kept the free-account install gate (it is a deliberate part of how the project works), but every item in `registry.json` now states it up front, so nobody has to install to find out. Free items read `Free account required to install; source is free to read.` and the design systems and templates read `Requires AI Canvas Premium to install.` Those labels are generated from the same manifest the server gate reads, so what the index advertises and what the endpoint serves cannot drift apart. This is live now.

**Control characters.** I could not reproduce this one. I pulled all 119 items from the live registry and strict-parsed every one with Node's `JSON.parse`, `jq`, and Python across gzip, brotli, and identity encodings; all clean, no literal control characters in any string. In case it was a transient edge or cache issue, I also added a build gate that strict-parses every file (including `registry.json` itself, which the old lint skipped) and rejects U+2028/U+2029/BOM, so it cannot slip through going forward. If your checker still flags something, tell me which item and which tool and I will dig in.

**Open source.** Fair, the layout was not obvious. The components are in the repo, they just were not sign-posted. Every free component's source is under `components-workspace/<slug>/` (the `.tsx` plus its remix prompt), and the Andromeda design system is under `design-systems/andromeda/`. The `/r/*.json` files are generated from those at build time, which is why there is no `registry/` folder to find. I added a Repository layout section to the README pointing straight at them.

Appreciate the detailed review on #104. Happy to adjust anything else.
