### PR TITLE
feat: agent-native submission pipeline

### DIFF
--- a/.claude/skills/review-submissions
+++ b/.claude/skills/review-submissions
@@ -1,0 +1,1 @@
+../../skills/review-submissions

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -7,3 +7,7 @@ NEXT_PUBLIC_AFFILIATES_ENABLED=true
 
 # Feedback widget (internal dogfooding)
 NEXT_PUBLIC_FEEDBACK_ENABLED=
+
+# Registry submissions (/api/submit): HMAC key for submission update tokens.
+# Without it, submissions still work but pending entries cannot be updated.
+SUBMISSION_SECRET=       # Generate with: openssl rand -hex 32

--- a/apps/web/app/api/submit/route.ts
+++ b/apps/web/app/api/submit/route.ts
@@ -1,14 +1,29 @@
 import { NextResponse } from "next/server";
 import {
   submissionSchema,
-  upsertSubmission,
+  getSubmission,
+  saveSubmission,
+  submissionToken,
+  isValidSubmissionToken,
   normalizeRegistryUrl,
 } from "@/lib/submissions";
 
 const DOCS_URL = "https://registry.directory/how-to-submit.md";
+const MAX_BODY_BYTES = 10_000;
 
 interface DirectoryFile {
   registries: Array<{ url: string; registry_url?: string }>;
+}
+
+// The dedupe source is always the canonical production directory — deriving
+// the origin from the incoming request would let a spoofed Host header point
+// this server-side fetch at an attacker-controlled URL. Local dev reads its
+// own origin so the flow works offline against the local file.
+function directoryJsonUrl(requestUrl: string): URL {
+  if (process.env.NODE_ENV === "development") {
+    return new URL("/directory.json", requestUrl);
+  }
+  return new URL("https://registry.directory/directory.json");
 }
 
 async function isAlreadyListed(
@@ -16,7 +31,7 @@ async function isAlreadyListed(
   registryUrl: string
 ): Promise<boolean> {
   try {
-    const response = await fetch(new URL("/directory.json", requestUrl), {
+    const response = await fetch(directoryJsonUrl(requestUrl), {
       cache: "no-store",
     });
     if (!response.ok) return false;
@@ -38,6 +53,17 @@ export async function POST(request: Request) {
     return NextResponse.json(
       { error: "Submission storage not configured. Try again later." },
       { status: 503 }
+    );
+  }
+
+  const contentLength = Number(request.headers.get("content-length"));
+  if (contentLength > MAX_BODY_BYTES) {
+    return NextResponse.json(
+      {
+        error: `Request body too large (max ${MAX_BODY_BYTES} bytes). A submission is a handful of short fields.`,
+        docs: DOCS_URL,
+      },
+      { status: 413 }
     );
   }
 
@@ -78,20 +104,80 @@ export async function POST(request: Request) {
   }
 
   try {
-    const { entry, created } = await upsertSubmission(parsed.data);
+    const existing = await getSubmission(parsed.data.registry_url);
+
+    if (existing) {
+      const providedToken =
+        typeof body === "object" && body !== null
+          ? (body as Record<string, unknown>).submission_token
+          : undefined;
+
+      if (!process.env.SUBMISSION_SECRET) {
+        return NextResponse.json(
+          {
+            error:
+              "A submission for this registry_url is already pending review and updates are not enabled. The pending version will be reviewed as-is.",
+            docs: DOCS_URL,
+          },
+          { status: 409 }
+        );
+      }
+
+      if (typeof providedToken !== "string" || providedToken === "") {
+        return NextResponse.json(
+          {
+            error:
+              "A submission for this registry_url is already pending review. To update it, include the submission_token field that was returned when it was created.",
+            docs: `${DOCS_URL}#updating-a-submission`,
+          },
+          { status: 403 }
+        );
+      }
+
+      if (!isValidSubmissionToken(parsed.data.registry_url, providedToken)) {
+        return NextResponse.json(
+          {
+            error:
+              "submission_token does not match this registry_url. Updates require the token returned when the submission was created.",
+            docs: `${DOCS_URL}#updating-a-submission`,
+          },
+          { status: 403 }
+        );
+      }
+
+      const entry = await saveSubmission(parsed.data, existing);
+      return NextResponse.json(
+        {
+          success: true,
+          id: entry.id,
+          status: entry.status,
+          message:
+            "Submission updated. The pending entry now reflects the fields you just sent.",
+          docs: DOCS_URL,
+        },
+        { status: 200 }
+      );
+    }
+
+    const entry = await saveSubmission(parsed.data, null);
+    const token = submissionToken(parsed.data.registry_url);
     return NextResponse.json(
       {
         success: true,
         id: entry.id,
         status: entry.status,
-        message: created
-          ? "Submission received and queued for review. A maintainer audits every submission (the registry must resolve with real, installable content) and you will see your registry listed once approved."
-          : "Submission updated. The pending entry now reflects the fields you just sent.",
-        update_hint:
-          "To change this submission, POST again with the same registry_url — it updates in place.",
+        ...(token
+          ? {
+              submission_token: token,
+              update_hint:
+                "Keep submission_token if you may want to update this submission — POST again with the same registry_url plus this token.",
+            }
+          : {}),
+        message:
+          "Submission received and queued for review. A maintainer audits every submission (the registry must resolve with real, installable content) and you will see your registry listed once approved.",
         docs: DOCS_URL,
       },
-      { status: created ? 201 : 200 }
+      { status: 201 }
     );
   } catch (error) {
     console.error("[submissions] API error:", error);

--- a/apps/web/app/api/submit/route.ts
+++ b/apps/web/app/api/submit/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import {
+  submissionSchema,
+  upsertSubmission,
+  normalizeRegistryUrl,
+} from "@/lib/submissions";
+
+const DOCS_URL = "https://registry.directory/how-to-submit.md";
+
+interface DirectoryFile {
+  registries: Array<{ url: string; registry_url?: string }>;
+}
+
+async function isAlreadyListed(
+  requestUrl: string,
+  registryUrl: string
+): Promise<boolean> {
+  try {
+    const response = await fetch(new URL("/directory.json", requestUrl), {
+      cache: "no-store",
+    });
+    if (!response.ok) return false;
+    const directory = (await response.json()) as DirectoryFile;
+    const normalized = normalizeRegistryUrl(registryUrl);
+    return directory.registries.some(
+      (entry) =>
+        (entry.registry_url &&
+          normalizeRegistryUrl(entry.registry_url) === normalized) ||
+        normalizeRegistryUrl(entry.url) === normalized
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(request: Request) {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    return NextResponse.json(
+      { error: "Submission storage not configured. Try again later." },
+      { status: 503 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        error: "Request body must be valid JSON.",
+        docs: DOCS_URL,
+      },
+      { status: 400 }
+    );
+  }
+
+  const parsed = submissionSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Validation failed. Fix the fields below and POST again.",
+        fields: parsed.error.flatten().fieldErrors,
+        docs: DOCS_URL,
+      },
+      { status: 400 }
+    );
+  }
+
+  if (await isAlreadyListed(request.url, parsed.data.registry_url)) {
+    return NextResponse.json(
+      {
+        error:
+          "This registry is already listed on registry.directory. No action needed.",
+        docs: DOCS_URL,
+      },
+      { status: 409 }
+    );
+  }
+
+  try {
+    const { entry, created } = await upsertSubmission(parsed.data);
+    return NextResponse.json(
+      {
+        success: true,
+        id: entry.id,
+        status: entry.status,
+        message: created
+          ? "Submission received and queued for review. A maintainer audits every submission (the registry must resolve with real, installable content) and you will see your registry listed once approved."
+          : "Submission updated. The pending entry now reflects the fields you just sent.",
+        update_hint:
+          "To change this submission, POST again with the same registry_url — it updates in place.",
+        docs: DOCS_URL,
+      },
+      { status: created ? 201 : 200 }
+    );
+  } catch (error) {
+    console.error("[submissions] API error:", error);
+    return NextResponse.json(
+      { error: "Failed to save submission. Try again later." },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -12,6 +12,7 @@ import { AffiliateDisclosure } from "@/components/affiliate-disclosure";
 import type { DirectoryEntry } from "@/lib/types";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { HeroTitle } from "@/components/hero-title";
+import { SubmitRegistryDialog } from "@/components/submit-registry-dialog";
 
 // Enable static generation
 export const dynamic = 'force-static'
@@ -95,7 +96,8 @@ export default async function Home() {
   ]);
   return (
     <main className="relative flex min-h-screen flex-col items-center justify-start pt-24 md:pt-32 pb-12 md:pb-20">
-      <div className="absolute top-4 right-4">
+      <div className="absolute top-4 right-4 flex items-center gap-2">
+        <SubmitRegistryDialog />
         <ThemeToggle />
       </div>
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -12,7 +12,6 @@ import { AffiliateDisclosure } from "@/components/affiliate-disclosure";
 import type { DirectoryEntry } from "@/lib/types";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { HeroTitle } from "@/components/hero-title";
-import { SubmitRegistryDialog } from "@/components/submit-registry-dialog";
 
 // Enable static generation
 export const dynamic = 'force-static'
@@ -96,8 +95,7 @@ export default async function Home() {
   ]);
   return (
     <main className="relative flex min-h-screen flex-col items-center justify-start pt-24 md:pt-32 pb-12 md:pb-20">
-      <div className="absolute top-4 right-4 flex items-center gap-2">
-        <SubmitRegistryDialog />
+      <div className="absolute top-4 right-4">
         <ThemeToggle />
       </div>
 

--- a/apps/web/components/directory-list.tsx
+++ b/apps/web/components/directory-list.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { ExternalLink as ExternalLinkIcon, Package, Plus, Star } from "lucide-react";
+import { ExternalLink as ExternalLinkIcon, Package, Star } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/github";
 import {
   Card,
@@ -25,6 +25,7 @@ import type { IndexedItem } from "@/lib/items-index";
 import { addUtmParams } from "@/lib/utm-utils";
 import { formatStars, formatRelativeTime } from "@/lib/format-utils";
 import { REGISTRY_TYPE_LABELS, REGISTRY_TYPE_ICONS } from "@/lib/registry-mappings";
+import { SubmitRegistryCard } from "@/components/submit-registry-dialog";
 
 interface ResultClickData {
   result_type: "registry" | "item";
@@ -35,7 +36,6 @@ interface ResultClickData {
 interface DirectoryListProps {
   entries: DirectoryEntry[];
   searchTerm?: string;
-  addCardUrl?: string;
   addCardLabel?: string;
   showViewButton?: boolean;
   stats?: Record<string, RegistryStats>;
@@ -45,8 +45,8 @@ interface DirectoryListProps {
   onResultClick?: (data: ResultClickData) => void;
 }
 
-export function DirectoryList({ entries, searchTerm = '', addCardUrl, addCardLabel, showViewButton = false, stats, githubStats, affiliates, itemResults = [], onResultClick }: DirectoryListProps) {
-  const showAddCard = !searchTerm && addCardUrl && addCardLabel;
+export function DirectoryList({ entries, searchTerm = '', addCardLabel, showViewButton = false, stats, githubStats, affiliates, itemResults = [], onResultClick }: DirectoryListProps) {
+  const showAddCard = !searchTerm && addCardLabel;
   const hasItems = itemResults.length > 0;
   const hasRegistries = entries.length > 0;
 
@@ -67,30 +67,7 @@ export function DirectoryList({ entries, searchTerm = '', addCardUrl, addCardLab
     {/* Registry cards — only shown when there are registry-level matches */}
     {hasRegistries && (
     <div className="w-full max-w-7xl mx-auto mt-6 md:mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-5 px-2">
-      {showAddCard && (
-        <a
-          href={addCardUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="h-full group"
-        >
-          <Card className="bg-background border border-border-subtle border-dashed rounded-none overflow-hidden shadow-none hover:shadow-lg hover:border-border transition-all h-full flex flex-col">
-            <CardHeader className="flex flex-col items-center justify-center gap-2 bg-background pt-4 pb-3 min-h-[100px]">
-              <div className="flex-shrink-0">
-                <Plus className="w-7 h-7 text-muted-foreground group-hover:text-foreground transition-colors" />
-              </div>
-              <CardTitle className="text-sm text-foreground text-center group-hover:text-foreground transition-colors">
-                {addCardLabel}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="px-3 pb-4 pt-0 bg-background flex-1 flex flex-col justify-between">
-              <CardDescription className="text-xs text-muted-foreground text-center">
-                Share your registry with the community
-              </CardDescription>
-            </CardContent>
-          </Card>
-        </a>
-      )}
+      {showAddCard && <SubmitRegistryCard label={addCardLabel} />}
 
       {entries.map((entry, index) => {
         const gh = entry.github_url ? githubStats?.[entry.github_url] : undefined;

--- a/apps/web/components/directory-tabs.tsx
+++ b/apps/web/components/directory-tabs.tsx
@@ -109,7 +109,6 @@ export function DirectoryTabs({ components, stats, githubStats, items, affiliate
     });
   }, [searchTerm, analytics]);
 
-  const addRegistryUrl = 'https://github.com/rbadillap/registry.directory';
 
   return (
     <div className="w-full max-w-7xl mx-auto px-4">
@@ -134,7 +133,6 @@ export function DirectoryTabs({ components, stats, githubStats, items, affiliate
           <DirectoryList
             entries={sortedComponents}
             searchTerm={searchTerm}
-            addCardUrl={addRegistryUrl}
             addCardLabel="Add your Registry"
             showViewButton={true}
             stats={stats}

--- a/apps/web/components/submit-registry-dialog.tsx
+++ b/apps/web/components/submit-registry-dialog.tsx
@@ -2,7 +2,13 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@workspace/ui/components/button";
-import { cn } from "@workspace/ui/lib/utils";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@workspace/ui/components/card";
 import { Check, Copy, Plus, X } from "lucide-react";
 
 const DOCS_PATH = "/how-to-submit.md";
@@ -33,115 +39,145 @@ function CopyBlock({ label, text }: { label: string; text: string }) {
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
-        <span className="text-xs font-medium text-muted-foreground">
-          {label}
-        </span>
+        <span className="font-mono text-xs text-muted-foreground">{label}</span>
         <Button
           type="button"
           variant="ghost"
           size="sm"
-          className="h-6 gap-1 px-2 text-xs"
+          className="h-6 gap-1.5 px-2 text-xs transition-[background-color,scale] active:scale-[0.96]"
           onClick={handleCopy}
         >
-          {copied ? (
-            <Check className="size-3" />
-          ) : (
-            <Copy className="size-3" />
-          )}
+          <span className="relative size-3">
+            <Copy
+              className={`absolute inset-0 size-3 transition-[opacity,scale,filter] duration-300 ease-[cubic-bezier(0.2,0,0,1)] ${
+                copied ? "scale-25 opacity-0 blur-[4px]" : "scale-100 opacity-100 blur-0"
+              }`}
+            />
+            <Check
+              className={`absolute inset-0 size-3 transition-[opacity,scale,filter] duration-300 ease-[cubic-bezier(0.2,0,0,1)] ${
+                copied ? "scale-100 opacity-100 blur-0" : "scale-25 opacity-0 blur-[4px]"
+              }`}
+            />
+          </span>
           {copied ? "Copied" : "Copy"}
         </Button>
       </div>
-      <pre className="overflow-x-auto rounded-md border bg-muted/50 p-2.5 font-mono text-xs leading-relaxed whitespace-pre-wrap break-all">
+      <pre className="overflow-x-auto border border-border-subtle bg-muted/40 p-2.5 font-mono text-xs leading-relaxed whitespace-pre-wrap break-all">
         {text}
       </pre>
     </div>
   );
 }
 
-export function SubmitRegistryDialog() {
-  const [isOpen, setIsOpen] = useState(false);
-  const close = useCallback(() => setIsOpen(false), []);
-
+function SubmitRegistryModal({ onClose }: { onClose: () => void }) {
   useEffect(() => {
-    if (!isOpen) return;
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") close();
+      if (e.key === "Escape") onClose();
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [isOpen, close]);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm animate-in fade-in-0 duration-200"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Submit your registry"
+    >
+      <div
+        className="max-h-[85vh] w-full max-w-lg overflow-y-auto border bg-background p-5 shadow-[0_0_0_1px_rgba(255,255,255,0.04),0_8px_24px_rgba(0,0,0,0.3),0_24px_64px_rgba(0,0,0,0.25)] animate-in fade-in-0 zoom-in-95 duration-200 ease-[cubic-bezier(0.2,0,0,1)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-start justify-between gap-4 animate-in fade-in-0 slide-in-from-bottom-2 fill-mode-backwards duration-300">
+          <div>
+            <h2 className="text-base font-semibold text-balance">
+              Submit your registry
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground text-pretty">
+              One POST, no account, no fork. Hand the instructions to your
+              agent — or run the request yourself.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="relative size-7 shrink-0 after:absolute after:-inset-2"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+
+        <div className="space-y-4">
+          <div
+            className="animate-in fade-in-0 slide-in-from-bottom-2 fill-mode-backwards duration-300"
+            style={{ animationDelay: "75ms" }}
+          >
+            <CopyBlock label="Tell your agent" text={AGENT_PROMPT} />
+          </div>
+          <div
+            className="animate-in fade-in-0 slide-in-from-bottom-2 fill-mode-backwards duration-300"
+            style={{ animationDelay: "150ms" }}
+          >
+            <CopyBlock label="Or do it yourself" text={CURL_SNIPPET} />
+          </div>
+        </div>
+
+        <p
+          className="mt-4 text-xs text-muted-foreground text-pretty animate-in fade-in-0 slide-in-from-bottom-2 fill-mode-backwards duration-300"
+          style={{ animationDelay: "225ms" }}
+        >
+          Full contract — fields, responses, updates:{" "}
+          <a
+            href={DOCS_PATH}
+            target="_blank"
+            rel="noreferrer"
+            className="font-mono text-foreground underline underline-offset-2"
+          >
+            /how-to-submit.md
+          </a>
+          . Every submission is audited before listing: your registry must
+          resolve with real, installable content.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function SubmitRegistryCard({ label }: { label: string }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const close = useCallback(() => setIsOpen(false), []);
 
   return (
     <>
-      <Button
+      <button
         type="button"
-        variant="outline"
-        size="sm"
-        className="gap-1.5"
         onClick={() => setIsOpen(true)}
+        className="group h-full w-full text-left transition-[scale] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-haspopup="dialog"
       >
-        <Plus className="size-3.5" />
-        Submit registry
-      </Button>
-
-      {isOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm"
-          onClick={close}
-          role="dialog"
-          aria-modal="true"
-          aria-label="Submit your registry"
-        >
-          <div
-            className={cn(
-              "w-full max-w-lg rounded-lg border bg-background p-5 shadow-lg",
-              "max-h-[85vh] overflow-y-auto"
-            )}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="mb-4 flex items-start justify-between gap-4">
-              <div>
-                <h2 className="text-base font-semibold">
-                  Submit your registry
-                </h2>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  One POST, no account, no fork. Hand the instructions to your
-                  agent — or run the request yourself.
-                </p>
-              </div>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="size-7 shrink-0"
-                onClick={close}
-                aria-label="Close"
-              >
-                <X className="size-4" />
-              </Button>
+        <Card className="flex h-full flex-col overflow-hidden rounded-none border border-dashed border-border-subtle bg-background shadow-none transition-[border-color,box-shadow] hover:border-border hover:shadow-lg">
+          <CardHeader className="flex min-h-[100px] flex-col items-center justify-center gap-2 bg-background pt-4 pb-3">
+            <div className="flex-shrink-0">
+              <Plus className="size-7 text-muted-foreground transition-[rotate,color] duration-300 ease-[cubic-bezier(0.2,0,0,1)] group-hover:rotate-90 group-hover:text-foreground" />
             </div>
+            <CardTitle className="text-center text-sm text-foreground">
+              {label}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-1 flex-col justify-between bg-background px-3 pt-0 pb-4">
+            <CardDescription className="text-center text-xs text-muted-foreground">
+              Share your registry with the community
+            </CardDescription>
+          </CardContent>
+        </Card>
+      </button>
 
-            <div className="space-y-4">
-              <CopyBlock label="Tell your agent" text={AGENT_PROMPT} />
-              <CopyBlock label="Or do it yourself" text={CURL_SNIPPET} />
-            </div>
-
-            <p className="mt-4 text-xs text-muted-foreground">
-              Full contract — fields, responses, updates:{" "}
-              <a
-                href={DOCS_PATH}
-                target="_blank"
-                rel="noreferrer"
-                className="font-mono text-foreground underline underline-offset-2"
-              >
-                /how-to-submit.md
-              </a>
-              . Every submission is audited before listing: your registry must
-              resolve with real, installable content.
-            </p>
-          </div>
-        </div>
-      )}
+      {isOpen && <SubmitRegistryModal onClose={close} />}
     </>
   );
 }

--- a/apps/web/components/submit-registry-dialog.tsx
+++ b/apps/web/components/submit-registry-dialog.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@workspace/ui/components/button";
+import { cn } from "@workspace/ui/lib/utils";
+import { Check, Copy, Plus, X } from "lucide-react";
+
+const DOCS_PATH = "/how-to-submit.md";
+const DOCS_URL = `https://registry.directory${DOCS_PATH}`;
+const AGENT_PROMPT = `Submit my shadcn registry to registry.directory following the instructions at ${DOCS_URL}`;
+const CURL_SNIPPET = `curl -X POST https://registry.directory/api/submit \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "name": "Your Registry",
+    "description": "What it provides.",
+    "url": "https://example.com/",
+    "registry_url": "https://example.com/r/registry.json"
+  }'`;
+
+function CopyBlock({ label, text }: { label: string; text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable — the text is still selectable below.
+    }
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">
+          {label}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1 px-2 text-xs"
+          onClick={handleCopy}
+        >
+          {copied ? (
+            <Check className="size-3" />
+          ) : (
+            <Copy className="size-3" />
+          )}
+          {copied ? "Copied" : "Copy"}
+        </Button>
+      </div>
+      <pre className="overflow-x-auto rounded-md border bg-muted/50 p-2.5 font-mono text-xs leading-relaxed whitespace-pre-wrap break-all">
+        {text}
+      </pre>
+    </div>
+  );
+}
+
+export function SubmitRegistryDialog() {
+  const [isOpen, setIsOpen] = useState(false);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") close();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, close]);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="gap-1.5"
+        onClick={() => setIsOpen(true)}
+      >
+        <Plus className="size-3.5" />
+        Submit registry
+      </Button>
+
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm"
+          onClick={close}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Submit your registry"
+        >
+          <div
+            className={cn(
+              "w-full max-w-lg rounded-lg border bg-background p-5 shadow-lg",
+              "max-h-[85vh] overflow-y-auto"
+            )}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-base font-semibold">
+                  Submit your registry
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  One POST, no account, no fork. Hand the instructions to your
+                  agent — or run the request yourself.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-7 shrink-0"
+                onClick={close}
+                aria-label="Close"
+              >
+                <X className="size-4" />
+              </Button>
+            </div>
+
+            <div className="space-y-4">
+              <CopyBlock label="Tell your agent" text={AGENT_PROMPT} />
+              <CopyBlock label="Or do it yourself" text={CURL_SNIPPET} />
+            </div>
+
+            <p className="mt-4 text-xs text-muted-foreground">
+              Full contract — fields, responses, updates:{" "}
+              <a
+                href={DOCS_PATH}
+                target="_blank"
+                rel="noreferrer"
+                className="font-mono text-foreground underline underline-offset-2"
+              >
+                /how-to-submit.md
+              </a>
+              . Every submission is audited before listing: your registry must
+              resolve with real, installable content.
+            </p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/lib/submissions.ts
+++ b/apps/web/lib/submissions.ts
@@ -1,0 +1,115 @@
+import { put } from "@vercel/blob";
+import { z } from "zod";
+
+const DOCS_URL = "https://registry.directory/how-to-submit.md";
+
+export const submissionSchema = z.object({
+  name: z
+    .string({ required_error: `name is required — the display name of your registry. See ${DOCS_URL}#fields` })
+    .min(1, "name cannot be empty")
+    .max(100, "name must be 100 characters or fewer"),
+  description: z
+    .string({ required_error: `description is required — one sentence describing what your registry provides. See ${DOCS_URL}#fields` })
+    .min(1, "description cannot be empty")
+    .max(300, "description must be 300 characters or fewer"),
+  url: z
+    .string({ required_error: `url is required — your registry's homepage. See ${DOCS_URL}#fields` })
+    .url("url must be a valid URL")
+    .startsWith("https://", "url must use https"),
+  registry_url: z
+    .string({ required_error: `registry_url is required — the direct URL to your registry.json file (e.g. https://example.com/r/registry.json). It is the unique key for your submission. See ${DOCS_URL}#fields` })
+    .url("registry_url must be a valid URL")
+    .startsWith("https://", "registry_url must use https"),
+  github_url: z
+    .string()
+    .url("github_url must be a valid URL")
+    .startsWith("https://github.com/", "github_url must be a https://github.com/ repository URL")
+    .optional(),
+  github_profile: z
+    .string()
+    .url("github_profile must be a valid URL")
+    .startsWith("https://", `github_profile must use https — typically https://github.com/<owner>.png. See ${DOCS_URL}#fields`)
+    .optional(),
+});
+
+export type SubmissionInput = z.infer<typeof submissionSchema>;
+
+export interface SubmissionEntry {
+  id: string;
+  status: "pending";
+  origin: "api";
+  submitted_at: string;
+  updated_at: string;
+  registry: SubmissionInput;
+}
+
+export function normalizeRegistryUrl(url: string): string {
+  return url.trim().toLowerCase().replace(/\/+$/, "");
+}
+
+export function submissionId(registryUrl: string): string {
+  return normalizeRegistryUrl(registryUrl)
+    .replace(/^https:\/\//, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 100);
+}
+
+function getBlobFilename(id: string): string {
+  return `submissions/pending/${id}.json`;
+}
+
+function getBlobPublicUrl(filename: string): string | null {
+  const blobToken = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!blobToken) return null;
+
+  const storeMatch = blobToken.match(/vercel_blob_rw_([^_]+)_/);
+  if (!storeMatch) return null;
+
+  return `https://${storeMatch[1]}.public.blob.vercel-storage.com/${filename}`;
+}
+
+async function readSubmissionBlob(
+  filename: string
+): Promise<SubmissionEntry | null> {
+  const url = getBlobPublicUrl(filename);
+  if (!url) return null;
+
+  try {
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) return null;
+    return (await response.json()) as SubmissionEntry;
+  } catch {
+    return null;
+  }
+}
+
+export async function upsertSubmission(
+  input: SubmissionInput
+): Promise<{ entry: SubmissionEntry; created: boolean }> {
+  const id = submissionId(input.registry_url);
+  const filename = getBlobFilename(id);
+  const existing = await readSubmissionBlob(filename);
+  const now = new Date().toISOString();
+
+  const entry: SubmissionEntry = {
+    id,
+    status: "pending",
+    origin: "api",
+    submitted_at: existing?.submitted_at ?? now,
+    updated_at: now,
+    registry: input,
+  };
+
+  await put(filename, JSON.stringify(entry, null, 2), {
+    access: "public",
+    token: process.env.BLOB_READ_WRITE_TOKEN,
+    addRandomSuffix: false,
+    allowOverwrite: true,
+  });
+
+  console.log(
+    `[submissions] ${existing ? "Updated" : "Created"} submission ${id}`
+  );
+  return { entry, created: !existing };
+}

--- a/apps/web/lib/submissions.ts
+++ b/apps/web/lib/submissions.ts
@@ -1,3 +1,4 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { put } from "@vercel/blob";
 import { z } from "zod";
 
@@ -47,12 +48,45 @@ export function normalizeRegistryUrl(url: string): string {
   return url.trim().toLowerCase().replace(/\/+$/, "");
 }
 
+// The readable slug alone is not injective (e.g. "r/registry.json" and
+// "r/registry-json" collapse to the same slug), which would let one URL
+// overwrite another URL's pending submission. The hash suffix guarantees
+// distinct URLs always map to distinct blob paths.
 export function submissionId(registryUrl: string): string {
-  return normalizeRegistryUrl(registryUrl)
+  const normalized = normalizeRegistryUrl(registryUrl);
+  const slug = normalized
     .replace(/^https:\/\//, "")
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "")
-    .slice(0, 100);
+    .slice(0, 80);
+  const hash = createHash("sha256").update(normalized).digest("hex").slice(0, 8);
+  return `${slug}-${hash}`;
+}
+
+// Stateless update credential: derived from the registry_url and a server
+// secret, so no token storage is needed. Returned once on creation; required
+// to overwrite a pending submission. Without it, anyone could deface a
+// pending submission by re-POSTing its registry_url with different fields.
+export function submissionToken(registryUrl: string): string | null {
+  const secret = process.env.SUBMISSION_SECRET;
+  if (!secret) return null;
+
+  return createHmac("sha256", secret)
+    .update(normalizeRegistryUrl(registryUrl))
+    .digest("hex");
+}
+
+export function isValidSubmissionToken(
+  registryUrl: string,
+  provided: string
+): boolean {
+  const expected = submissionToken(registryUrl);
+  if (!expected) return false;
+
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const providedBuffer = Buffer.from(provided, "utf8");
+  if (expectedBuffer.length !== providedBuffer.length) return false;
+  return timingSafeEqual(expectedBuffer, providedBuffer);
 }
 
 function getBlobFilename(id: string): string {
@@ -69,10 +103,10 @@ function getBlobPublicUrl(filename: string): string | null {
   return `https://${storeMatch[1]}.public.blob.vercel-storage.com/${filename}`;
 }
 
-async function readSubmissionBlob(
-  filename: string
+export async function getSubmission(
+  registryUrl: string
 ): Promise<SubmissionEntry | null> {
-  const url = getBlobPublicUrl(filename);
+  const url = getBlobPublicUrl(getBlobFilename(submissionId(registryUrl)));
   if (!url) return null;
 
   try {
@@ -84,12 +118,11 @@ async function readSubmissionBlob(
   }
 }
 
-export async function upsertSubmission(
-  input: SubmissionInput
-): Promise<{ entry: SubmissionEntry; created: boolean }> {
+export async function saveSubmission(
+  input: SubmissionInput,
+  existing: SubmissionEntry | null
+): Promise<SubmissionEntry> {
   const id = submissionId(input.registry_url);
-  const filename = getBlobFilename(id);
-  const existing = await readSubmissionBlob(filename);
   const now = new Date().toISOString();
 
   const entry: SubmissionEntry = {
@@ -101,7 +134,7 @@ export async function upsertSubmission(
     registry: input,
   };
 
-  await put(filename, JSON.stringify(entry, null, 2), {
+  await put(getBlobFilename(id), JSON.stringify(entry, null, 2), {
     access: "public",
     token: process.env.BLOB_READ_WRITE_TOKEN,
     addRandomSuffix: false,
@@ -111,5 +144,5 @@ export async function upsertSubmission(
   console.log(
     `[submissions] ${existing ? "Updated" : "Created"} submission ${id}`
   );
-  return { entry, created: !existing };
+  return entry;
 }

--- a/apps/web/public/how-to-submit.md
+++ b/apps/web/public/how-to-submit.md
@@ -1,0 +1,64 @@
+# How to submit a registry to registry.directory
+
+You are (or are acting for) the author of a shadcn/ui component registry. This document is the complete contract for getting it listed on [registry.directory](https://registry.directory). One HTTP POST is all it takes — no account, no fork, no pull request.
+
+## Prerequisites
+
+Your registry must:
+
+1. Be publicly reachable over **https**.
+2. Serve a `registry.json` index (shadcn registry schema) with a non-empty `items` array.
+3. Resolve honestly: individual item JSONs must return real, installable content — actual source code in `files[].content` — or, if items are gated behind a license/paywall, the gating must be declared in the index rather than silently returning empty files. Submissions that don't resolve are rejected.
+
+Before submitting, verify yourself: fetch your `registry.json` and 2–3 individual item URLs and confirm they return what a `shadcn add` would need.
+
+## Fields
+
+Derive every field from data you already control. Fetch your own `registry.json` if you need `name` or homepage values.
+
+| Field | Required | What to send |
+|---|---|---|
+| `name` | yes | Display name of the registry (max 100 chars), e.g. `"usva."` |
+| `description` | yes | One sentence describing what the registry provides (max 300 chars) |
+| `url` | yes | Homepage, https, e.g. `"https://example.com/"` |
+| `registry_url` | yes | Direct https URL to the `registry.json` index. **This is the unique key of your submission** — updates and deduplication match on it |
+| `github_url` | no | Source repository, must start with `https://github.com/` |
+| `github_profile` | no | Avatar URL, typically `https://github.com/<owner>.png` |
+
+## Submit
+
+```bash
+curl -X POST https://registry.directory/api/submit \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Example UI",
+    "description": "Composable data-viz components built on the shadcn registry standard.",
+    "url": "https://example.com/",
+    "registry_url": "https://example.com/r/registry.json",
+    "github_url": "https://github.com/acme/example-ui",
+    "github_profile": "https://github.com/acme.png"
+  }'
+```
+
+## Responses
+
+| Status | Meaning | What to do |
+|---|---|---|
+| `201` | Submission created and queued for review | Done. Save the returned `id` for reference |
+| `200` | Existing pending submission updated in place | Done |
+| `400` | Body is not valid JSON, or field validation failed | Read `fields` in the response — each key lists exactly what is wrong — fix and POST again |
+| `409` | This registry is already listed | Nothing to do |
+| `503` | Storage temporarily unavailable | Retry later |
+| `500` | Server error | Retry later; if persistent, open an issue at [rbadillap/registry.directory](https://github.com/rbadillap/registry.directory/issues) |
+
+## Updating a submission
+
+POST again with the same `registry_url`. The pending submission is replaced by the new payload (upsert). There is nothing else to manage — no tokens, no edit endpoints.
+
+## What happens after you submit
+
+1. A maintainer's agent audits the submission: it fetches your `registry.json` and several individual items, and verifies they resolve with real content (the criterion in [Prerequisites](#prerequisites)).
+2. A human maintainer makes the final decision.
+3. On approval, your registry is committed to the directory and appears on the site after the next build. Review typically takes a few days.
+
+Questions or corrections after listing: open an issue or PR at [rbadillap/registry.directory](https://github.com/rbadillap/registry.directory).

--- a/apps/web/public/how-to-submit.md
+++ b/apps/web/public/how-to-submit.md
@@ -1,20 +1,22 @@
 # How to submit a registry to registry.directory
 
-You are (or are acting for) the author of a shadcn/ui component registry. This document is the complete contract for getting it listed on [registry.directory](https://registry.directory). One HTTP POST is all it takes — no account, no fork, no pull request.
+You are (or are acting for) the author of a [shadcn/ui component registry](https://ui.shadcn.com/docs/registry). This document is the complete contract for getting it listed on [registry.directory](https://registry.directory). One HTTP POST is all it takes — no account, no fork, no pull request.
+
+Everything you submit is public by design: accepted registries are listed in a public [directory.json](https://registry.directory/directory.json), and pending submissions are reviewable data, not private records.
 
 ## Prerequisites
 
 Your registry must:
 
 1. Be publicly reachable over **https**.
-2. Serve a `registry.json` index (shadcn registry schema) with a non-empty `items` array.
-3. Resolve honestly: individual item JSONs must return real, installable content — actual source code in `files[].content` — or, if items are gated behind a license/paywall, the gating must be declared in the index rather than silently returning empty files. Submissions that don't resolve are rejected.
+2. Serve a `registry.json` index conforming to the [registry.json schema](https://ui.shadcn.com/docs/registry/registry-json), with a non-empty `items` array.
+3. Resolve honestly: individual item JSONs (see the [registry-item schema](https://ui.shadcn.com/docs/registry/registry-item-json)) must return real, installable content — actual source code in `files[].content` — or, if items are gated behind a license/paywall, the gating must be declared in the index rather than silently returning empty files. Submissions that don't resolve are rejected.
 
-Before submitting, verify yourself: fetch your `registry.json` and 2–3 individual item URLs and confirm they return what a `shadcn add` would need.
+Before submitting, verify yourself: fetch your `registry.json` and 2–3 individual item URLs and confirm they return what `npx shadcn@latest add <item-url>` ([CLI docs](https://ui.shadcn.com/docs/cli)) would need. If you haven't built the registry yet, start from the [shadcn registry guide](https://ui.shadcn.com/docs/registry/getting-started) or the [registry template](https://github.com/shadcn-ui/registry-template).
 
 ## Fields
 
-Derive every field from data you already control. Fetch your own `registry.json` if you need `name` or homepage values.
+Derive every field from data you already control. Fetch your own `registry.json` if you need `name` or homepage values. The accepted entry ends up in the directory following [this JSON schema](https://registry.directory/schemas/directory.json).
 
 | Field | Required | What to send |
 |---|---|---|
@@ -44,16 +46,32 @@ curl -X POST https://registry.directory/api/submit \
 
 | Status | Meaning | What to do |
 |---|---|---|
-| `201` | Submission created and queued for review | Done. Save the returned `id` for reference |
+| `201` | Submission created and queued for review | Done. Save the returned `id` and `submission_token` — the token is the only credential for updating this submission and is shown exactly once |
 | `200` | Existing pending submission updated in place | Done |
 | `400` | Body is not valid JSON, or field validation failed | Read `fields` in the response — each key lists exactly what is wrong — fix and POST again |
-| `409` | This registry is already listed | Nothing to do |
+| `403` | A pending submission exists for this `registry_url` and the `submission_token` is missing or wrong | Retry with the token from the creation response. Lost it? The pending version will be reviewed as-is |
+| `409` | This registry is already listed, or a pending submission exists and updates are disabled | Nothing to do |
+| `413` | Body larger than 10 KB | A submission is a handful of short fields — trim and retry |
 | `503` | Storage temporarily unavailable | Retry later |
 | `500` | Server error | Retry later; if persistent, open an issue at [rbadillap/registry.directory](https://github.com/rbadillap/registry.directory/issues) |
 
 ## Updating a submission
 
-POST again with the same `registry_url`. The pending submission is replaced by the new payload (upsert). There is nothing else to manage — no tokens, no edit endpoints.
+POST again with the same `registry_url`, all fields, plus the `submission_token` you received on creation:
+
+```bash
+curl -X POST https://registry.directory/api/submit \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Example UI",
+    "description": "An improved description.",
+    "url": "https://example.com/",
+    "registry_url": "https://example.com/r/registry.json",
+    "submission_token": "<token from the 201 response>"
+  }'
+```
+
+The pending submission is replaced by the new payload. The token exists so only the original submitter can touch a pending submission — without it, updates are rejected but the original submission stays intact and will be reviewed.
 
 ## What happens after you submit
 
@@ -62,3 +80,12 @@ POST again with the same `registry_url`. The pending submission is replaced by t
 3. On approval, your registry is committed to the directory and appears on the site after the next build. Review typically takes a few days.
 
 Questions or corrections after listing: open an issue or PR at [rbadillap/registry.directory](https://github.com/rbadillap/registry.directory).
+
+## References
+
+- [shadcn registry docs](https://ui.shadcn.com/docs/registry) — what a registry is and how distribution works
+- [registry.json schema](https://ui.shadcn.com/docs/registry/registry-json) — the index your `registry_url` must serve
+- [registry-item.json schema](https://ui.shadcn.com/docs/registry/registry-item-json) — what each item must return
+- [Getting started](https://ui.shadcn.com/docs/registry/getting-started) · [registry template](https://github.com/shadcn-ui/registry-template) — build a registry from scratch
+- [shadcn CLI](https://ui.shadcn.com/docs/cli) — how consumers install from your registry
+- [directory.json schema](https://registry.directory/schemas/directory.json) — the shape of an accepted directory entry

--- a/apps/web/scripts/list-pending-submissions.mjs
+++ b/apps/web/scripts/list-pending-submissions.mjs
@@ -1,0 +1,25 @@
+// Lists pending registry submissions stored in Vercel Blob.
+// Usage (from apps/web):  node --env-file=.env.local scripts/list-pending-submissions.mjs
+import { list } from "@vercel/blob";
+
+if (!process.env.BLOB_READ_WRITE_TOKEN) {
+  console.error("BLOB_READ_WRITE_TOKEN is not set. Run with --env-file=.env.local");
+  process.exit(1);
+}
+
+const { blobs } = await list({ prefix: "submissions/pending/" });
+
+if (blobs.length === 0) {
+  console.log("No pending submissions.");
+  process.exit(0);
+}
+
+const entries = await Promise.all(
+  blobs.map(async (blob) => {
+    const response = await fetch(blob.url, { cache: "no-store" });
+    return response.json();
+  })
+);
+
+entries.sort((a, b) => a.submitted_at.localeCompare(b.submitted_at));
+console.log(JSON.stringify(entries, null, 2));

--- a/skills/review-submissions/SKILL.md
+++ b/skills/review-submissions/SKILL.md
@@ -73,3 +73,10 @@ These exist because public actions represent the maintainer personally:
 
 - **Approved**: add the entry to `apps/web/public/directory.json` (match the existing format and the schema in `apps/web/public/schemas/directory.json`), commit on a branch, open a PR for the maintainer unless instructed otherwise. Then delete the pending blob (`submissions/pending/<id>.json`) so the inbox stays truthful.
 - **Rejected**: delete the pending blob. Any communication to the author is the maintainer's, per the boundaries above.
+
+## References for the probe
+
+- [registry.json schema](https://ui.shadcn.com/docs/registry/registry-json) — what a valid index looks like
+- [registry-item.json schema](https://ui.shadcn.com/docs/registry/registry-item-json) — what a valid item looks like; `files[].content` is where real code lives
+- [shadcn CLI](https://ui.shadcn.com/docs/cli) — `npx shadcn@latest add <item-url>` is the consumer behavior the probe simulates
+- `apps/web/public/how-to-submit.md` — the contract submitters were given; what they were promised is what you audit against

--- a/skills/review-submissions/SKILL.md
+++ b/skills/review-submissions/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: review-submissions
+description: Audit pending registry submissions for registry.directory and produce an admission verdict for the maintainer. Use this whenever asked to review submissions, check the submission inbox, audit a new registry, review a PR that touches directory.json, or when the maintainer asks what arrived ("what's new?", "anything pending?"). Always follow this procedure instead of improvising a review.
+---
+
+# Review Registry Submissions
+
+registry.directory lists shadcn/ui component registries. Anyone can submit one (see `apps/web/public/how-to-submit.md`). Your job is to **audit** each pending submission and report a verdict. You do not admit, reject, merge, or reply to submitters — the maintainer (@rbadillap) makes every final decision and personally writes any public response. This split is deliberate: the audit is mechanical and yours; judgment on edge cases and hospitality toward authors are his.
+
+## The admission criterion
+
+The directory audits **honest resolution, not business models**. A registry is admissible when the URLs it publishes resolve to what they promise:
+
+- **Admissible**: items return real, installable source code in `files[].content` — OR items are gated (license/paywall) and the gating is declared in the index rather than hidden.
+- **Not admissible**: index or items that 404, return HTML instead of JSON, contain empty/placeholder file content, or silently gate content while presenting as open.
+- **Popularity is irrelevant.** Zero stars, brand-new projects, and third-party submissions (submitter ≠ registry owner) are all acceptable. Only resolution matters.
+
+When a case does not clearly fit (partially gated without declaration, index resolves but many items broken, claims that contradict reality), do not force a verdict — mark it NEEDS_HUMAN with the evidence.
+
+## Step 1 — Gather the inbox
+
+Check both sources; either may have items the other doesn't:
+
+```bash
+# API submissions (Vercel Blob), run from apps/web:
+node --env-file=.env.local scripts/list-pending-submissions.mjs
+
+# Manual submissions (GitHub PRs that touch directory.json):
+gh pr list --state open --json number,title,author,createdAt,files \
+  --jq '.[] | select(.files[].path == "apps/web/public/directory.json")'
+```
+
+If both are empty, report "no pending submissions" and stop.
+
+## Step 2 — Run the probe on each submission
+
+Never skip steps, and never conclude from the index alone — an index can be healthy while every item is broken.
+
+1. **Index**: fetch `registry_url`. It must return valid JSON with a non-empty `items` array. Record the item count and the mix of types.
+2. **Items**: pick 3–5 items spread across different types (ui, block, lib, etc. — not 5 of the same kind). Fetch each item's individual JSON from the same base URL pattern. For each, verify `files[].content` holds real source code: non-trivial length and plausible content for its declared path (a `.tsx` file should read as TypeScript/React). Record per-item file counts and content sizes — they are your evidence.
+3. **Declared fields vs reality**: the submitted `name`/`description` must reasonably match what the registry actually serves, and `url` must be a live homepage. Mismatches are a signal of carelessness or misrepresentation — note them.
+4. **Source repo**: if `github_url` was provided, confirm the repo exists and is public (`gh repo view owner/repo`). Note whether the submitter appears to be the owner (informative, not required).
+
+## Origin determines scrutiny, not leniency
+
+- **API submissions** (`origin: "api"` in the Blob entry): nobody tested anything by hand before it reached you — the API validates only field format. Your probe is the first and only audit. Apply every step fully.
+- **PR submissions**: even when the PR author says they tested an install, run the full probe anyway. Verify, don't trust.
+
+## Step 3 — Report the verdict
+
+Deliver one report for the whole inbox, most recent submission first. For each submission use exactly this structure:
+
+```
+### <name> — PASS | FAIL | NEEDS_HUMAN
+- Source: api submission <id> | PR #<n>
+- Index: <item count> items at <registry_url> (<types summary>)
+- Items probed: <name> (<n> files, <total chars>), <name> (…), …
+- Fields vs reality: <ok | discrepancies>
+- Repo: <exists/public/owner-match | not provided>
+- Notes: <anything the maintainer should weigh — edge cases, oddities, standout quality>
+```
+
+End the report with a one-line recommendation per submission. Do not act on it — wait for the maintainer's decision.
+
+## Boundaries
+
+These exist because public actions represent the maintainer personally:
+
+- Never merge a PR, never commit to `directory.json`, never delete a submission blob — those follow the maintainer's decision, not the audit.
+- Never post PR comments, issues, or any public reply. If a welcome or rejection message is wanted, draft it, show it, and publish only after explicit approval of the exact text.
+
+## After the maintainer decides
+
+- **Approved**: add the entry to `apps/web/public/directory.json` (match the existing format and the schema in `apps/web/public/schemas/directory.json`), commit on a branch, open a PR for the maintainer unless instructed otherwise. Then delete the pending blob (`submissions/pending/<id>.json`) so the inbox stays truthful.
+- **Rejected**: delete the pending blob. Any communication to the author is the maintainer's, per the boundaries above.


### PR DESCRIPTION
## What this is

First implementation of the agent-native submission flow: registries are submitted with one HTTP POST — no account, no fork, no manual PR. Submissions land in Vercel Blob as pure data; review and the final decision stay with the maintainer.

## Pieces

- **`POST /api/submit`** — receptionist, not auditor: validates field *format* only (zod, mirroring `schemas/directory.json`), zero server-side fetches of submitted URLs. Field-level error messages teach the caller exactly what to fix (agents self-correct in their retry loop). Dedupes against `directory.json`; re-POSTing the same `registry_url` upserts the pending entry in place. Storage clones the proven feedback-module pattern (`lib/feedback.ts`).
- **`/how-to-submit.md`** — the complete submission contract as a static route. Humans copy the URL and hand it to their agent; agents follow it directly. Fields are derived by the submitter's agent from their own `registry.json` — the derivation compute is theirs.
- **`skills/review-submissions/`** — the audit procedure as a formal skill: inbox gathering (Blob + PRs), the resolution probe (index + 3–5 items, real code or declared gating), origin-based scrutiny (API submissions get full probe — nobody hand-tested them), verdict format, and hard boundaries (audit ≠ decide; public replies require approved text). Canonical at repo root, symlinked into `.claude/skills/` — portable to other agent tooling.
- **`scripts/list-pending-submissions.mjs`** — reads the Blob inbox (`node --env-file=.env.local scripts/list-pending-submissions.mjs` from `apps/web`).

## Tested

- `pnpm typecheck` and `pnpm lint` clean (only pre-existing warnings in untouched files)
- Live against dev server: `/how-to-submit.md` serves as `text/markdown`; invalid JSON → 400; missing/invalid fields → 400 with per-field guidance; already-listed registry → 409 (dedupe verified against real `directory.json`)
- Not tested live: the Blob write path (201/200) — needs a real `BLOB_READ_WRITE_TOKEN`; the code path is identical to the production feedback module
- Skill triggering verified: the symlink registers `review-submissions` in Claude Code

## Deliberately out of scope

- Frontend "Add registry" dialog (UI work, separate effort)
- Rate limiting (consistent with the feedback endpoint; revisit if abuse appears)
- README still documents the manual-PR path — worth updating once this flow is live