### PR TITLE
fix: authoritative existence check and safer URL normalization

### DIFF
--- a/apps/web/lib/submissions.ts
+++ b/apps/web/lib/submissions.ts
@@ -1,5 +1,5 @@
 import { createHash, createHmac, timingSafeEqual } from "node:crypto";
-import { put } from "@vercel/blob";
+import { list, put } from "@vercel/blob";
 import { z } from "zod";
 
 const DOCS_URL = "https://registry.directory/how-to-submit.md";
@@ -44,8 +44,16 @@ export interface SubmissionEntry {
   registry: SubmissionInput;
 }
 
+// Scheme and host are case-insensitive per URL semantics; the path is NOT —
+// lowercasing it would collapse genuinely distinct registry paths onto one
+// submission id. new URL() lowercases scheme/host and drops default ports.
 export function normalizeRegistryUrl(url: string): string {
-  return url.trim().toLowerCase().replace(/\/+$/, "");
+  try {
+    const parsed = new URL(url.trim());
+    return parsed.origin + parsed.pathname.replace(/\/+$/, "") + parsed.search;
+  } catch {
+    return url.trim().replace(/\/+$/, "");
+  }
 }
 
 // The readable slug alone is not injective (e.g. "r/registry.json" and
@@ -103,16 +111,34 @@ function getBlobPublicUrl(filename: string): string | null {
   return `https://${storeMatch[1]}.public.blob.vercel-storage.com/${filename}`;
 }
 
+export interface PendingSubmissionRef {
+  submitted_at: string;
+}
+
+// Existence MUST be checked against the Blob API (authoritative), not the
+// public CDN URL: reads through the CDN right after a write can miss the
+// blob, which would let an update slip past the token gate as a "create".
 export async function getSubmission(
   registryUrl: string
-): Promise<SubmissionEntry | null> {
-  const url = getBlobPublicUrl(getBlobFilename(submissionId(registryUrl)));
-  if (!url) return null;
+): Promise<PendingSubmissionRef | null> {
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) return null;
 
+  const pathname = getBlobFilename(submissionId(registryUrl));
   try {
-    const response = await fetch(url, { cache: "no-store" });
-    if (!response.ok) return null;
-    return (await response.json()) as SubmissionEntry;
+    const { blobs } = await list({ prefix: pathname, token, limit: 1 });
+    const blob = blobs.find((b) => b.pathname === pathname);
+    if (!blob) return null;
+
+    // Cache-busting query so the CDN can't serve a stale copy; if the copy
+    // still isn't readable, the blob's uploadedAt approximates submitted_at.
+    const response = await fetch(`${blob.url}?v=${Date.now()}`, {
+      cache: "no-store",
+    });
+    if (response.ok) {
+      return (await response.json()) as SubmissionEntry;
+    }
+    return { submitted_at: new Date(blob.uploadedAt).toISOString() };
   } catch {
     return null;
   }
@@ -120,7 +146,7 @@ export async function getSubmission(
 
 export async function saveSubmission(
   input: SubmissionInput,
-  existing: SubmissionEntry | null
+  existing: PendingSubmissionRef | null
 ): Promise<SubmissionEntry> {
   const id = submissionId(input.registry_url);
   const now = new Date().toISOString();
@@ -139,6 +165,9 @@ export async function saveSubmission(
     token: process.env.BLOB_READ_WRITE_TOKEN,
     addRandomSuffix: false,
     allowOverwrite: true,
+    // Shortest allowed CDN cache — narrows the stale-read window for any
+    // consumer that reads the public URL.
+    cacheControlMaxAge: 60,
   });
 
   console.log(

--- a/apps/web/scripts/list-pending-submissions.mjs
+++ b/apps/web/scripts/list-pending-submissions.mjs
@@ -16,7 +16,11 @@ if (blobs.length === 0) {
 
 const entries = await Promise.all(
   blobs.map(async (blob) => {
-    const response = await fetch(blob.url, { cache: "no-store" });
+    // Cache-busting query — the public URL goes through the Blob CDN, which
+    // can serve stale content right after an update.
+    const response = await fetch(`${blob.url}?v=${Date.now()}`, {
+      cache: "no-store",
+    });
     return response.json();
   })
 );


### PR DESCRIPTION
## What this fixes

Production canary testing after #108 surfaced two defects (tests 9/10 vs 11 of the battery):

1. **Token gate bypass via CDN staleness (security).** Pending-submission existence was read from the blob's public CDN URL. Read-after-write through the CDN is not guaranteed: when the read missed, the endpoint treated an update as a create and wrote **without token verification** — probabilistically bypassing the anti-defacement protection. Existence is now checked against the Blob API (`list()`), which is authoritative. Content is still read from the public URL but with a cache-busting query; if unreadable, `uploadedAt` approximates `submitted_at`.

2. **Over-aggressive normalization.** `normalizeRegistryUrl` lowercased the whole URL, but URL paths are case-sensitive — two registries differing only in path case would collide onto one submission id (second one blocked by the first's token gate). Normalization now uses `new URL()` semantics: scheme/host lowercased, default port dropped, path case preserved, trailing slashes stripped.

3. **Stale inbox reads.** `list-pending-submissions.mjs` fetched blob URLs through the same CDN; added cache-busting so the review skill never audits stale data. Writes now set `cacheControlMaxAge: 60`.

## Verified locally

- `pnpm typecheck` clean, lint clean
- Unit tests: host-case-insensitive ids, path case preserved, trailing slash normalized, slug injectivity intact, tokens survive host-case variants and reject path-case variants

## After merge

Full 12-test battery re-runs against production (create/update/forge/normalization/injectivity), then canary blobs are deleted and the inbox verified empty.