### PR TITLE
feat: add @agents-ui (LiveKit) to the directory

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -477,6 +477,14 @@
       "registry_url": "https://usva.build/r/registry.json",
       "github_url": "https://github.com/matt-pasek/usva",
       "github_profile": "https://github.com/matt-pasek.png"
+    },
+    {
+      "name": "@agents-ui",
+      "description": "LiveKit components for building voice and video AI agent interfaces: control bars, audio visualizers, track toggles, and session blocks.",
+      "url": "https://livekit.com/ui",
+      "registry_url": "https://livekit.com/ui/r/registry.json",
+      "github_url": "https://github.com/livekit/components-js",
+      "github_profile": "https://github.com/livekit.png"
     }
   ]
 }


### PR DESCRIPTION
## First admission through the agent-native pipeline 🎉

Submitted via `POST /api/submit` (blob `livekit-com-ui-r-registry-json-c7d4e3f6`), audited with the `review-submissions` skill, approved by @rbadillap.

**Audit summary — PASS:**
- Index: 17 items at https://livekit.com/ui/r/registry.json (14 component, 1 page, 1 block, 1 item)
- Probed 5 items across all 4 types: agent-control-bar (18.5K chars), agent-session-view-01 (4 files, 23.4K), agent-audio-visualizer-bar (8K), agent-track-toggle (4.7K), nextjs-api-token-route (2.8K) — all real TSX/TS
- The `all` item (0 files) is a valid aggregator bundle (15 registryDependencies)
- Fields match reality; repo public and active

The pending blob will be deleted once this merges.