### PR TITLE
feat: affiliate entries for Shadcn Blocks, Aceternity, Magic UI and Cult UI

### DIFF
--- a/apps/web/public/affiliates.json
+++ b/apps/web/public/affiliates.json
@@ -23,6 +23,12 @@
       "affiliate_url": "https://pro.magicui.design/?ref=registrydirectory",
       "label": "Magic UI",
       "program": "magic-ui"
+    },
+    {
+      "url": "https://cult-ui.com",
+      "affiliate_url": "https://pro.cult-ui.com/?atp=registrydirectory",
+      "label": "Cult UI",
+      "program": "cult-ui"
     }
   ]
 }

--- a/apps/web/public/affiliates.json
+++ b/apps/web/public/affiliates.json
@@ -11,6 +11,12 @@
       "affiliate_url": "https://www.shadcnblocks.com/?via=registrydirectory",
       "label": "Shadcn Blocks",
       "program": "shadcn-blocks"
+    },
+    {
+      "url": "https://ui.aceternity.com/",
+      "affiliate_url": "https://ui.aceternity.com/?ref=registrydirectory",
+      "label": "Aceternity UI",
+      "program": "aceternity-ui"
     }
   ]
 }

--- a/apps/web/public/affiliates.json
+++ b/apps/web/public/affiliates.json
@@ -5,6 +5,12 @@
       "affiliate_url": "https://shadcnstudio.com/?ref=registrydirectory",
       "label": "Shadcn Studio",
       "program": "shadcn-studio"
+    },
+    {
+      "url": "https://shadcnblocks.com",
+      "affiliate_url": "https://www.shadcnblocks.com/?via=registrydirectory",
+      "label": "Shadcn Blocks",
+      "program": "shadcn-blocks"
     }
   ]
 }

--- a/apps/web/public/affiliates.json
+++ b/apps/web/public/affiliates.json
@@ -17,6 +17,12 @@
       "affiliate_url": "https://ui.aceternity.com/?ref=registrydirectory",
       "label": "Aceternity UI",
       "program": "aceternity-ui"
+    },
+    {
+      "url": "https://magicui.design/",
+      "affiliate_url": "https://pro.magicui.design/?ref=registrydirectory",
+      "label": "Magic UI",
+      "program": "magic-ui"
     }
   ]
 }


### PR DESCRIPTION
Adds four affiliate entries to `affiliates.json`, joining the existing shadcn/studio entry. Data-only change — no code touched; the Visit CTA on each registry's surfaces resolves to the referral link via the existing `getAffiliates()` join by `entry.url`.

- Shadcn Blocks → `shadcnblocks.com/?via=registrydirectory` (Rewardful)
- Aceternity UI → `ui.aceternity.com/?ref=registrydirectory` (Tolt)
- Magic UI → `pro.magicui.design/?ref=registrydirectory` (Tolt)
- Cult UI → `pro.cult-ui.com/?atp=registrydirectory` (Affonso)

All five join keys verified against `directory.json`; all referral URLs verified live. Affiliate status never affects ranking or visibility; disclosure at `/disclosure`.
