### PR TITLE
feat: search-first home, Premium only filter, discovery instrumentation

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -52,6 +52,7 @@ async function getRegistries(): Promise<DirectoryEntry[]> {
       github_url: registry.github_url,
       github_profile: registry.github_profile,
       registry_url: registry.registry_url,
+      pro: registry.pro,
     }));
   } catch (error) {
     console.error("Error reading directory.json:", error);

--- a/apps/web/components/directory-list.tsx
+++ b/apps/web/components/directory-list.tsx
@@ -23,6 +23,7 @@ import {
 import type { DirectoryEntry, GitHubStats, RegistryStats, AffiliateConfig } from "@/lib/types";
 import type { IndexedItem } from "@/lib/items-index";
 import { addUtmParams } from "@/lib/utm-utils";
+import { useAnalytics } from "@/hooks/use-analytics";
 import { formatStars, formatRelativeTime } from "@/lib/format-utils";
 import { REGISTRY_TYPE_LABELS, REGISTRY_TYPE_ICONS } from "@/lib/registry-mappings";
 import { SubmitRegistryCard } from "@/components/submit-registry-dialog";
@@ -43,9 +44,11 @@ interface DirectoryListProps {
   affiliates?: Record<string, AffiliateConfig>;
   itemResults?: IndexedItem[];
   onResultClick?: (data: ResultClickData) => void;
+  premiumFilterActive?: boolean;
 }
 
-export function DirectoryList({ entries, searchTerm = '', addCardLabel, showViewButton = false, stats, githubStats, affiliates, itemResults = [], onResultClick }: DirectoryListProps) {
+export function DirectoryList({ entries, searchTerm = '', addCardLabel, showViewButton = false, stats, githubStats, affiliates, itemResults = [], onResultClick, premiumFilterActive = false }: DirectoryListProps) {
+  const { trackHomeRegistryVisit } = useAnalytics();
   const showAddCard = !searchTerm && addCardLabel;
   const hasItems = itemResults.length > 0;
   const hasRegistries = entries.length > 0;
@@ -131,6 +134,11 @@ export function DirectoryList({ entries, searchTerm = '', addCardLabel, showView
                     rel="noopener noreferrer"
                     aria-label={`Visit ${entry.name} website`}
                     className="text-foreground-subtle hover:text-muted-foreground transition-colors"
+                    onClick={() => trackHomeRegistryVisit({
+                      registry: entry.name,
+                      sponsored: Boolean(affiliate),
+                      premium_filter_active: premiumFilterActive,
+                    })}
                   >
                     <ExternalLinkIcon className="w-3.5 h-3.5" />
                   </a>

--- a/apps/web/components/directory-tabs.tsx
+++ b/apps/web/components/directory-tabs.tsx
@@ -1,16 +1,26 @@
 'use client';
 
-import { useMemo, useDeferredValue, useEffect, useCallback } from 'react';
+import { useState, useMemo, useDeferredValue, useEffect, useCallback } from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';
 import { DirectoryList } from './directory-list';
 import { SearchBar } from './search-bar';
-import { useAnalytics, type SearchResultType } from '@/hooks/use-analytics';
+import { useAnalytics, type SearchResultType, type HomeTab } from '@/hooks/use-analytics';
 import { useUrlState } from '@/hooks/use-url-state';
 import type { DirectoryEntry, GitHubStats, RegistryStats, AffiliateConfig } from '@/lib/types';
 import type { IndexedItem } from '@/lib/items-index';
 import { searchItems } from '@/lib/search-utils';
 
 type SortMode = 'popular' | 'stars' | 'recently-active';
+
+function filterBySearch(entries: DirectoryEntry[], searchTerm: string): DirectoryEntry[] {
+  if (!searchTerm) return entries;
+  const term = searchTerm.toLowerCase();
+  return entries.filter(entry =>
+    entry.name.toLowerCase().includes(term) ||
+    entry.description.toLowerCase().includes(term) ||
+    entry.url.toLowerCase().includes(term)
+  );
+}
 
 type GitHubStatsRecord = Record<string, Omit<GitHubStats, 'fetchedAt'>>;
 
@@ -69,15 +79,23 @@ export function DirectoryTabs({ components, stats, githubStats, items, affiliate
   const { activeTab, setActiveTab, searchTerm, setSearchTerm } = useUrlState();
   const deferredSearchTerm = useDeferredValue(searchTerm);
 
-  const filteredComponents = useMemo(() => {
-    if (!searchTerm) return components;
-    const term = searchTerm.toLowerCase();
-    return components.filter(entry =>
-      entry.name.toLowerCase().includes(term) ||
-      entry.description.toLowerCase().includes(term) ||
-      entry.url.toLowerCase().includes(term)
-    );
-  }, [components, searchTerm]);
+  const [premiumOnly, setPremiumOnly] = useState(false);
+
+  const filteredComponents = useMemo(
+    () => filterBySearch(premiumOnly ? components.filter(entry => entry.pro) : components, searchTerm),
+    [components, searchTerm, premiumOnly]
+  );
+
+  const handlePremiumToggle = useCallback(() => {
+    const enabled = !premiumOnly;
+    setPremiumOnly(enabled);
+    analytics.trackPremiumToggled({
+      enabled,
+      active_tab: activeTab as HomeTab,
+      has_query: Boolean(searchTerm),
+      results_count: filterBySearch(enabled ? components.filter(entry => entry.pro) : components, searchTerm).length,
+    });
+  }, [premiumOnly, activeTab, searchTerm, components, analytics]);
 
   // Sort the (filtered) registries by the active tab. Search filters, sort orders.
   const sortedComponents = useMemo(
@@ -98,8 +116,9 @@ export function DirectoryTabs({ components, stats, githubStats, items, affiliate
       active_tab: activeTab as SortMode,
       registry_results_count: sortedComponents.length,
       item_results_count: filteredItems.length,
+      premium_only: premiumOnly,
     });
-  }, [deferredSearchTerm, activeTab, sortedComponents.length, filteredItems.length, analytics]);
+  }, [deferredSearchTerm, activeTab, sortedComponents.length, filteredItems.length, premiumOnly, analytics]);
 
   const handleResultClick = useCallback((result: { result_type: SearchResultType; result_name: string; result_position: number }) => {
     if (!searchTerm) return;
@@ -113,19 +132,56 @@ export function DirectoryTabs({ components, stats, githubStats, items, affiliate
   return (
     <div className="w-full max-w-7xl mx-auto px-4">
       <Tabs defaultValue="popular" value={activeTab} onValueChange={setActiveTab}>
-        <div className="sticky top-0 z-10 bg-background flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-6 mb-4 md:mb-6 py-3">
-          <TabsList>
-            <TabsTrigger value="popular">Popular</TabsTrigger>
-            <TabsTrigger value="stars">Stars</TabsTrigger>
-            <TabsTrigger value="recently-active">Recently active</TabsTrigger>
-          </TabsList>
+        <div className="sticky top-0 z-10 bg-background flex flex-col gap-3 mb-4 md:mb-6 py-3">
+          <SearchBar
+            large
+            value={searchTerm}
+            onChange={setSearchTerm}
+            placeholder="Search registries and components..."
+          />
 
-          <div className="flex-1 w-full sm:w-auto">
-            <SearchBar
-              value={searchTerm}
-              onChange={setSearchTerm}
-              placeholder="Search registries and components..."
-            />
+          <div className="flex flex-wrap items-center gap-4 sm:gap-6">
+            <TabsList>
+              <TabsTrigger value="popular">Popular</TabsTrigger>
+              <TabsTrigger value="stars">Stars</TabsTrigger>
+              <TabsTrigger value="recently-active">Recently active</TabsTrigger>
+            </TabsList>
+
+            <div className="h-4 w-px bg-border" aria-hidden="true" />
+
+            <button
+              type="button"
+              role="switch"
+              aria-checked={premiumOnly}
+              onClick={handlePremiumToggle}
+              className="group inline-flex items-center gap-2 py-2 font-mono text-sm font-medium transition-colors"
+            >
+              <span
+                aria-hidden="true"
+                className={`flex h-4 w-7 items-center border p-0.5 transition-colors ${
+                  premiumOnly
+                    ? "justify-end border-emerald-500/60 bg-emerald-500/15"
+                    : "justify-start border-border bg-transparent"
+                }`}
+              >
+                <span
+                  className={`h-2.5 w-2.5 transition-colors ${
+                    premiumOnly
+                      ? "bg-emerald-500 dark:bg-emerald-400"
+                      : "bg-muted-foreground group-hover:bg-foreground-secondary"
+                  }`}
+                />
+              </span>
+              <span
+                className={
+                  premiumOnly
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-muted-foreground group-hover:text-foreground-secondary"
+                }
+              >
+                Premium only
+              </span>
+            </button>
           </div>
         </div>
 
@@ -140,6 +196,7 @@ export function DirectoryTabs({ components, stats, githubStats, items, affiliate
             affiliates={affiliates}
             itemResults={filteredItems}
             onResultClick={handleResultClick}
+            premiumFilterActive={premiumOnly}
           />
         </TabsContent>
       </Tabs>

--- a/apps/web/components/search-bar.tsx
+++ b/apps/web/components/search-bar.tsx
@@ -7,9 +7,10 @@ interface SearchBarProps {
   onChange: (value: string) => void;
   placeholder?: string;
   className?: string;
+  large?: boolean;
 }
 
-export function SearchBar({ value, onChange, placeholder = "Search registries and components...", className }: SearchBarProps) {
+export function SearchBar({ value, onChange, placeholder = "Search registries and components...", className, large }: SearchBarProps) {
   const handleClear = () => {
     onChange('');
   };
@@ -17,14 +18,14 @@ export function SearchBar({ value, onChange, placeholder = "Search registries an
   return (
     <div className={className}>
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+        <Search className={`absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground ${large ? "w-5 h-5 left-4" : "w-4 h-4"}`} />
         <input
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
           aria-label={placeholder}
-          className="w-full pl-10 pr-10 py-2 bg-background border border-input rounded-none text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground outline-none transition-[color,box-shadow] font-mono text-sm focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+          className={`w-full pr-10 bg-background border border-input rounded-none text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground outline-none transition-[color,box-shadow] font-mono focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 ${large ? "pl-12 py-3.5 text-base" : "pl-10 py-2 text-sm"}`}
           autoComplete="off"
           spellCheck="false"
         />

--- a/apps/web/components/submit-registry-dialog.tsx
+++ b/apps/web/components/submit-registry-dialog.tsx
@@ -91,15 +91,9 @@ function SubmitRegistryModal({ onClose }: { onClose: () => void }) {
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-start justify-between gap-4 animate-in fade-in-0 slide-in-from-bottom-2 fill-mode-backwards duration-300">
-          <div>
-            <h2 className="text-base font-semibold text-balance">
-              Submit your registry
-            </h2>
-            <p className="mt-1 text-sm text-muted-foreground text-pretty">
-              One POST, no account, no fork. Hand the instructions to your
-              agent — or run the request yourself.
-            </p>
-          </div>
+          <h2 className="text-base font-semibold text-balance">
+            Submit your registry
+          </h2>
           <Button
             type="button"
             variant="ghost"
@@ -117,13 +111,13 @@ function SubmitRegistryModal({ onClose }: { onClose: () => void }) {
             className="animate-in fade-in-0 slide-in-from-bottom-2 fill-mode-backwards duration-300"
             style={{ animationDelay: "75ms" }}
           >
-            <CopyBlock label="Tell your agent" text={AGENT_PROMPT} />
+            <CopyBlock label="Agent prompt" text={AGENT_PROMPT} />
           </div>
           <div
             className="animate-in fade-in-0 slide-in-from-bottom-2 fill-mode-backwards duration-300"
             style={{ animationDelay: "150ms" }}
           >
-            <CopyBlock label="Or do it yourself" text={CURL_SNIPPET} />
+            <CopyBlock label="curl" text={CURL_SNIPPET} />
           </div>
         </div>
 
@@ -131,7 +125,7 @@ function SubmitRegistryModal({ onClose }: { onClose: () => void }) {
           className="mt-4 text-xs text-muted-foreground text-pretty animate-in fade-in-0 slide-in-from-bottom-2 fill-mode-backwards duration-300"
           style={{ animationDelay: "225ms" }}
         >
-          Full contract — fields, responses, updates:{" "}
+          Docs:{" "}
           <a
             href={DOCS_PATH}
             target="_blank"
@@ -140,8 +134,8 @@ function SubmitRegistryModal({ onClose }: { onClose: () => void }) {
           >
             /how-to-submit.md
           </a>
-          . Every submission is audited before listing: your registry must
-          resolve with real, installable content.
+          {" "}· Every submission is audited before listing. Your registry
+          must resolve with real, installable content.
         </p>
       </div>
     </div>

--- a/apps/web/hooks/use-analytics.ts
+++ b/apps/web/hooks/use-analytics.ts
@@ -15,6 +15,8 @@ import {
   type RegistryVisitProperties,
   type SearchPerformedProperties,
   type SearchResultClickedProperties,
+  type PremiumToggledProperties,
+  type HomeRegistryVisitProperties,
   type AIProvider,
   type ShareMethod,
   type ExportMethod,
@@ -191,6 +193,26 @@ export function useAnalytics() {
     [analytics, context]
   );
 
+  const trackPremiumToggled = useCallback(
+    (properties: Omit<PremiumToggledProperties, keyof RegistryContext>) => {
+      analytics.trackPremiumToggled({
+        ...context,
+        ...properties,
+      });
+    },
+    [analytics, context]
+  );
+
+  const trackHomeRegistryVisit = useCallback(
+    (properties: Omit<HomeRegistryVisitProperties, keyof RegistryContext>) => {
+      analytics.trackHomeRegistryVisit({
+        ...context,
+        ...properties,
+      });
+    },
+    [analytics, context]
+  );
+
   // Debounced tracking methods for high-frequency events
   const trackSearchUsedDebounced = useMemo(
     () => debounce(trackSearchUsed, 500),
@@ -224,6 +246,10 @@ export function useAnalytics() {
     // Home search
     trackSearchPerformed: trackSearchPerformedDebounced,
     trackSearchResultClicked,
+
+    // Home discovery
+    trackPremiumToggled,
+    trackHomeRegistryVisit,
 
     // Debounced methods
     trackSearchUsed: trackSearchUsedDebounced,

--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -105,6 +105,7 @@ export interface SearchPerformedProperties {
   active_tab: HomeTab;
   registry_results_count: number;
   item_results_count: number;
+  premium_only: boolean;
 }
 
 export interface SearchResultClickedProperties {
@@ -112,6 +113,19 @@ export interface SearchResultClickedProperties {
   result_type: SearchResultType;
   result_name: string;
   result_position: number;
+}
+
+export interface PremiumToggledProperties {
+  enabled: boolean;
+  active_tab: HomeTab;
+  has_query: boolean;
+  results_count: number;
+}
+
+export interface HomeRegistryVisitProperties {
+  registry: string;
+  sponsored: boolean;
+  premium_filter_active: boolean;
 }
 
 // ============================================================================
@@ -137,6 +151,10 @@ export const ANALYTICS_EVENTS = {
   // Home search
   HOME_SEARCH_PERFORMED: "home.search.performed",
   HOME_SEARCH_RESULT_CLICKED: "home.search.result_clicked",
+
+  // Home discovery
+  HOME_PREMIUM_TOGGLED: "home.premium.toggled",
+  HOME_REGISTRY_VISIT: "home.registry.visit",
 } as const;
 
 // ============================================================================
@@ -318,6 +336,14 @@ class Analytics {
 
   trackSearchResultClicked(properties: SearchResultClickedProperties & Partial<BaseEventProperties>): void {
     this.#trackEvent(ANALYTICS_EVENTS.HOME_SEARCH_RESULT_CLICKED, properties);
+  }
+
+  trackPremiumToggled(properties: PremiumToggledProperties & Partial<BaseEventProperties>): void {
+    this.#trackEvent(ANALYTICS_EVENTS.HOME_PREMIUM_TOGGLED, properties);
+  }
+
+  trackHomeRegistryVisit(properties: HomeRegistryVisitProperties & Partial<BaseEventProperties>): void {
+    this.#trackEvent(ANALYTICS_EVENTS.HOME_REGISTRY_VISIT, properties);
   }
 }
 


### PR DESCRIPTION
Reworks the home top section and instruments the discovery funnel.

## UI
- Search bar becomes the primary element: full-width, larger, above the controls.
- Sort tabs (Popular / Stars / Recently active) move below it, followed by a new **Premium only** toggle — a switch that filters the list to registries with a declared `pro` offering. Composable with any sort and with search.
- Fix: the home page field whitelist in `getRegistries()` now passes `pro` through (the filter found zero matches without it).
- Submit dialog copy reduced to the operative content: agent prompt, curl, and the audit criterion.

## Instrumentation (3 new signals)
- `home.premium.toggled` — { enabled, active_tab, has_query, results_count }
- `home.registry.visit` — { registry, sponsored, premium_filter_active }: first tracking of home-card click-outs
- `home.search.performed` gains `premium_only`

All three verified firing in dev console. The filter criterion is the declared `pro` field only — affiliate status never affects filtering or ordering.
