### PR TITLE
perf: build index disk cache, parallel param collection, separate dev dist dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ coverage
 
 # Build Outputs
 .next/
+.next-dev/
 out/
 build
 dist

--- a/apps/web/app/(app)/[owner]/[repo]/[slug]/page.tsx
+++ b/apps/web/app/(app)/[owner]/[repo]/[slug]/page.tsx
@@ -30,30 +30,36 @@ export async function generateMetadata({
 
 export async function generateStaticParams() {
   const registries = await loadDirectory()
-  const params: { owner: string; repo: string; slug: string }[] = []
 
-  for (const registry of registries) {
-    const gh = parseGithubRef(registry.github_url)
-    if (!gh) continue
+  const results = await Promise.allSettled(
+    registries.map(async (registry) => {
+      const gh = parseGithubRef(registry.github_url)
+      if (!gh) return []
 
-    const index = await fetchRegistryIndex(registry, 10000)
-    if (!index) continue
+      const index = await fetchRegistryIndex(registry, 10000)
+      if (!index) return []
 
-    const categoriesMap = groupItemsByCategory(index.items)
+      const params: { owner: string; repo: string; slug: string }[] = []
+      const categoriesMap = groupItemsByCategory(index.items)
 
-    for (const category of categoriesMap.keys()) {
-      params.push({ owner: gh.owner, repo: gh.repo, slug: category })
-    }
-
-    for (const item of index.items) {
-      if (!hasOnlyRenderableFiles(item.files)) {
-        continue
+      for (const category of categoriesMap.keys()) {
+        params.push({ owner: gh.owner, repo: gh.repo, slug: category })
       }
-      params.push({ owner: gh.owner, repo: gh.repo, slug: item.name })
-    }
-  }
 
-  return params
+      for (const item of index.items) {
+        if (!hasOnlyRenderableFiles(item.files)) {
+          continue
+        }
+        params.push({ owner: gh.owner, repo: gh.repo, slug: item.name })
+      }
+
+      return params
+    })
+  )
+
+  return results.flatMap((result) =>
+    result.status === "fulfilled" ? result.value : []
+  )
 }
 
 export default async function SlugPage({

--- a/apps/web/app/(app)/[owner]/[repo]/[slug]/page.tsx
+++ b/apps/web/app/(app)/[owner]/[repo]/[slug]/page.tsx
@@ -39,6 +39,11 @@ export async function generateStaticParams() {
       const index = await fetchRegistryIndex(registry, 10000)
       if (!index) return []
 
+      // Prerender only categories + featured items; the item long tail
+      // renders on demand via dynamicParams. Measured over 30 days, humans
+      // visit ~340 distinct item pages while categories, landings and
+      // featured cover ~86% of traffic — prebaking all ~19k item pages
+      // spent the whole build on pages nobody requests before they expire.
       const params: { owner: string; repo: string; slug: string }[] = []
       const categoriesMap = groupItemsByCategory(index.items)
 
@@ -46,11 +51,13 @@ export async function generateStaticParams() {
         params.push({ owner: gh.owner, repo: gh.repo, slug: category })
       }
 
-      for (const item of index.items) {
-        if (!hasOnlyRenderableFiles(item.files)) {
+      const byName = new Map(index.items.map((item) => [item.name, item]))
+      for (const name of registry.featured ?? []) {
+        const item = byName.get(name)
+        if (!item || !hasOnlyRenderableFiles(item.files)) {
           continue
         }
-        params.push({ owner: gh.owner, repo: gh.repo, slug: item.name })
+        params.push({ owner: gh.owner, repo: gh.repo, slug: name })
       }
 
       return params

--- a/apps/web/app/(app)/[owner]/[repo]/page.tsx
+++ b/apps/web/app/(app)/[owner]/[repo]/page.tsx
@@ -63,43 +63,48 @@ export async function generateMetadata({
 
 export async function generateStaticParams() {
   const registries = await loadDirectory()
-  const params: { owner: string; repo: string }[] = []
 
-  for (const registry of registries) {
-    // Canonical github pairs
-    const gh = parseGithubRef(registry.github_url)
-    if (gh) {
-      params.push({ owner: gh.owner, repo: gh.repo })
-      continue
-    }
-
-    // Github-less entries: /{handle}/{category|item} pages. Prerender only
-    // categories + featured items — some of these catalogs are huge (4k+
-    // items, many paywalled) and would double the daily build; the rest
-    // renders on demand via dynamicParams.
-    const handle = entryHandle(registry)
-    if (!handle) continue
-
-    const index = await fetchRegistryIndex(registry, 10000)
-    if (!index) continue
-
-    const categoriesMap = groupItemsByCategory(index.items)
-
-    for (const category of categoriesMap.keys()) {
-      params.push({ owner: handle, repo: category })
-    }
-
-    const byName = new Map(index.items.map((item) => [item.name, item]))
-    for (const name of registry.featured ?? []) {
-      const item = byName.get(name)
-      if (!item || !hasOnlyRenderableFiles(item.files)) {
-        continue
+  const results = await Promise.allSettled(
+    registries.map(async (registry) => {
+      // Canonical github pairs
+      const gh = parseGithubRef(registry.github_url)
+      if (gh) {
+        return [{ owner: gh.owner, repo: gh.repo }]
       }
-      params.push({ owner: handle, repo: name })
-    }
-  }
 
-  return params
+      // Github-less entries: /{handle}/{category|item} pages. Prerender only
+      // categories + featured items — some of these catalogs are huge (4k+
+      // items, many paywalled) and would double the daily build; the rest
+      // renders on demand via dynamicParams.
+      const handle = entryHandle(registry)
+      if (!handle) return []
+
+      const index = await fetchRegistryIndex(registry, 10000)
+      if (!index) return []
+
+      const params: { owner: string; repo: string }[] = []
+      const categoriesMap = groupItemsByCategory(index.items)
+
+      for (const category of categoriesMap.keys()) {
+        params.push({ owner: handle, repo: category })
+      }
+
+      const byName = new Map(index.items.map((item) => [item.name, item]))
+      for (const name of registry.featured ?? []) {
+        const item = byName.get(name)
+        if (!item || !hasOnlyRenderableFiles(item.files)) {
+          continue
+        }
+        params.push({ owner: handle, repo: name })
+      }
+
+      return params
+    })
+  )
+
+  return results.flatMap((result) =>
+    result.status === "fulfilled" ? result.value : []
+  )
 }
 
 export default async function RegistryLandingPage({

--- a/apps/web/app/(app)/[owner]/[repo]/page.tsx
+++ b/apps/web/app/(app)/[owner]/[repo]/page.tsx
@@ -73,9 +73,8 @@ export async function generateStaticParams() {
       }
 
       // Github-less entries: /{handle}/{category|item} pages. Prerender only
-      // categories + featured items — some of these catalogs are huge (4k+
-      // items, many paywalled) and would double the daily build; the rest
-      // renders on demand via dynamicParams.
+      // categories + featured items, same policy as the github-backed
+      // [slug] route; the rest renders on demand via dynamicParams.
       const handle = entryHandle(registry)
       if (!handle) return []
 

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -21,36 +21,47 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   try {
     const registries = await loadDirectory()
 
-    for (const registry of registries) {
-      // Canonical prefix: /{owner}/{repo} for github-backed entries,
-      // /{handle} for namespaced ones. Redirect-only handle aliases are
-      // intentionally not listed — redirects don't belong in sitemaps.
-      const basePath = registryBasePath(registry)
-      if (!basePath) continue
+    const perRegistry = await Promise.allSettled(
+      registries.map(async (registry): Promise<MetadataRoute.Sitemap> => {
+        // Canonical prefix: /{owner}/{repo} for github-backed entries,
+        // /{handle} for namespaced ones. Redirect-only handle aliases are
+        // intentionally not listed — redirects don't belong in sitemaps.
+        const basePath = registryBasePath(registry)
+        if (!basePath) return []
 
-      // Add registry overview page
-      entries.push({
-        url: `${baseUrl}${basePath}`,
-        lastModified: new Date(),
-        changeFrequency: 'weekly',
-        priority: 0.8,
-      })
+        // Registry overview page
+        const urls: MetadataRoute.Sitemap = [
+          {
+            url: `${baseUrl}${basePath}`,
+            lastModified: new Date(),
+            changeFrequency: 'weekly',
+            priority: 0.8,
+          },
+        ]
 
-      // Fetch registry items
-      const registryData = await fetchRegistryIndex(registry, 10000)
-      if (!registryData) continue
+        const registryData = await fetchRegistryIndex(registry, 10000)
+        if (!registryData) return urls
 
-      for (const item of registryData.items) {
-        if (!hasOnlyRenderableFiles(item.files)) {
-          continue
+        for (const item of registryData.items) {
+          if (!hasOnlyRenderableFiles(item.files)) {
+            continue
+          }
+
+          urls.push({
+            url: `${baseUrl}${basePath}/${item.name}`,
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
+            priority: 0.6,
+          })
         }
 
-        entries.push({
-          url: `${baseUrl}${basePath}/${item.name}`,
-          lastModified: new Date(),
-          changeFrequency: 'monthly',
-          priority: 0.6,
-        })
+        return urls
+      })
+    )
+
+    for (const result of perRegistry) {
+      if (result.status === 'fulfilled') {
+        entries.push(...result.value)
       }
     }
   } catch (error) {

--- a/apps/web/lib/build-cache.ts
+++ b/apps/web/lib/build-cache.ts
@@ -1,0 +1,56 @@
+import { createHash } from "node:crypto"
+import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+// Registry indexes over 2MB bypass Next's data cache ("items over 2MB can not
+// be cached"), so during static generation every page of a large registry
+// re-downloads its index — 600+ round trips per build for a single registry.
+// This file cache in tmpdir shares one download per index across all build
+// workers. Active only while building; dev and production serving never use it.
+
+const CACHE_DIR = join(tmpdir(), "registry-directory-index-cache")
+const MAX_AGE_MS = 60 * 60 * 1000
+
+function isBuildPhase(): boolean {
+  return (
+    process.env.NEXT_PHASE === "phase-production-build" ||
+    process.env.NEXT_PHASE === "phase-export"
+  )
+}
+
+function cachePath(url: string): string {
+  const hash = createHash("sha1").update(url).digest("hex")
+  return join(CACHE_DIR, `${hash}.json`)
+}
+
+export async function readCachedJson<T>(url: string): Promise<T | null> {
+  if (!isBuildPhase()) return null
+
+  try {
+    const path = cachePath(url)
+    const info = await stat(path)
+    if (Date.now() - info.mtimeMs > MAX_AGE_MS) return null
+    return JSON.parse(await readFile(path, "utf8")) as T
+  } catch {
+    return null
+  }
+}
+
+export async function writeCachedJson(
+  url: string,
+  data: unknown
+): Promise<void> {
+  if (!isBuildPhase()) return
+
+  try {
+    await mkdir(CACHE_DIR, { recursive: true })
+    const path = cachePath(url)
+    // Write-then-rename keeps concurrent workers from reading partial files
+    const tmp = `${path}.${process.pid}.tmp`
+    await writeFile(tmp, JSON.stringify(data), "utf8")
+    await rename(tmp, path)
+  } catch {
+    // Best-effort: the network path still works without the cache
+  }
+}

--- a/apps/web/lib/build-cache.ts
+++ b/apps/web/lib/build-cache.ts
@@ -1,15 +1,18 @@
 import { createHash } from "node:crypto"
 import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 // Registry indexes over 2MB bypass Next's data cache ("items over 2MB can not
 // be cached"), so during static generation every page of a large registry
 // re-downloads its index — 600+ round trips per build for a single registry.
-// This file cache in tmpdir shares one download per index across all build
-// workers. Active only while building; dev and production serving never use it.
+// This file cache shares one download per index across all build workers.
+// Active only while building; dev and production serving never use it.
+//
+// Lives under .next/cache (not tmpdir: turbo's strict env mode strips TMPDIR,
+// splitting the cache across launchers). Vercel persists .next/cache between
+// builds, so production builds warm-start too; the TTL keeps daily data fresh.
 
-const CACHE_DIR = join(tmpdir(), "registry-directory-index-cache")
+const CACHE_DIR = join(process.cwd(), ".next", "cache", "registry-index")
 const MAX_AGE_MS = 60 * 60 * 1000
 
 function isBuildPhase(): boolean {

--- a/apps/web/lib/registry-items.ts
+++ b/apps/web/lib/registry-items.ts
@@ -1,32 +1,26 @@
-import { registryFetch, getRegistryJsonUrl } from "./fetch-utils";
 import { hasOnlyRenderableFiles } from "./file-utils";
-import type { Registry } from "./registry-types";
 import type { DirectoryEntry } from "./types";
 import type { IndexedItem } from "./items-index";
-import { registryBasePath, parseGithubRef } from "./resolve-registry";
+import {
+  registryBasePath,
+  parseGithubRef,
+  fetchRegistryIndex,
+} from "./resolve-registry";
 
 async function fetchItemsForRegistry(
   registry: DirectoryEntry
 ): Promise<IndexedItem[]> {
-  const url = getRegistryJsonUrl(registry);
   // Entries with neither github_url nor namespace have no route on the site
   const basePath = registryBasePath(registry);
-  if (!url || !basePath) return [];
+  if (!basePath) return [];
 
   const gh = parseGithubRef(registry.github_url);
   const avatarUrl = gh
     ? `https://github.com/${gh.owner}.png`
     : (registry.github_profile ?? null);
 
-  const response = await registryFetch(url, {
-    timeout: 10000,
-    next: { revalidate: 86400 },
-  });
-
-  if (!response.ok) return [];
-
-  const data = (await response.json()) as Registry;
-  if (!data.items || data.items.length === 0) return [];
+  const data = await fetchRegistryIndex(registry, 10000);
+  if (!data?.items || data.items.length === 0) return [];
 
   return data.items
     .filter((item) => hasOnlyRenderableFiles(item.files))

--- a/apps/web/lib/registry-stats.ts
+++ b/apps/web/lib/registry-stats.ts
@@ -1,45 +1,26 @@
-import { registryFetch, getRegistryJsonUrl } from "./fetch-utils";
 import { groupItemsByCategory } from "./registry-mappings";
-import type { Registry } from "./registry-types";
+import { fetchRegistryIndex } from "./resolve-registry";
 import type { DirectoryEntry, RegistryStats } from "./types";
 
 async function fetchStatsForRegistry(
   registry: DirectoryEntry
 ): Promise<RegistryStats | null> {
-  const url = getRegistryJsonUrl(registry);
-  if (!url) return null;
+  const data = await fetchRegistryIndex(registry, 10000);
+  if (!data?.items || data.items.length === 0) return null;
 
-  try {
-    const response = await registryFetch(url, {
-      timeout: 5000,
-      next: { revalidate: 86400 },
-    });
+  const grouped = groupItemsByCategory(data.items);
 
-    if (!response.ok) return null;
+  const categories = Array.from(grouped.entries())
+    .map(([slug, items]) => ({ slug, count: items.length }))
+    .sort((a, b) => b.count - a.count);
 
-    const data = (await response.json()) as Registry;
-    if (!data.items || data.items.length === 0) return null;
+  const topItems = data.items.slice(0, 5).map((item) => item.name);
 
-    const grouped = groupItemsByCategory(data.items);
-
-    const categories = Array.from(grouped.entries())
-      .map(([slug, items]) => ({ slug, count: items.length }))
-      .sort((a, b) => b.count - a.count);
-
-    const topItems = data.items.slice(0, 5).map((item) => item.name);
-
-    return {
-      totalItems: data.items.length,
-      categories,
-      topItems,
-    };
-  } catch (error) {
-    console.error(
-      `[registry-stats] Failed to fetch stats for ${registry.name}:`,
-      error
-    );
-    return null;
-  }
+  return {
+    totalItems: data.items.length,
+    categories,
+    topItems,
+  };
 }
 
 export async function fetchAllRegistryStats(

--- a/apps/web/lib/resolve-registry.ts
+++ b/apps/web/lib/resolve-registry.ts
@@ -3,6 +3,7 @@ import { join } from "node:path"
 import type { DirectoryEntry } from "./types"
 import type { Registry } from "./registry-types"
 import { registryFetch, getRegistryJsonUrl } from "./fetch-utils"
+import { readCachedJson, writeCachedJson } from "./build-cache"
 
 export type GithubRef = { owner: string; repo: string }
 
@@ -68,13 +69,18 @@ export async function fetchRegistryIndex(
   const targetUrl = getRegistryJsonUrl(entry)
   if (!targetUrl) return null
 
+  const cached = await readCachedJson<Registry>(targetUrl)
+  if (cached) return cached
+
   try {
     const response = await registryFetch(targetUrl, {
       timeout,
       next: { revalidate: 86400 },
     })
     if (!response.ok) return null
-    return (await response.json()) as Registry
+    const data = (await response.json()) as Registry
+    await writeCachedJson(targetUrl, data)
+    return data
   } catch (error) {
     console.error(`[Registry] Index fetch error for ${entry.name}:`, error)
     return null

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@workspace/ui"],
+  // next dev and next build corrupt each other when they share .next —
+  // separate dirs let a production build run while the dev server is up
+  distDir: process.env.NODE_ENV === "development" ? ".next-dev" : ".next",
   outputFileTracingIncludes: {
     '/[owner]/[repo]/opengraph-image': ['./public/fonts/**/*'],
     '/[owner]/[repo]/[slug]/opengraph-image': ['./public/fonts/**/*'],

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -3,8 +3,12 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"],
-      "@workspace/ui/*": ["../../packages/ui/src/*"]
+      "@/*": [
+        "./*"
+      ],
+      "@workspace/ui/*": [
+        "../../packages/ui/src/*"
+      ]
     },
     "plugins": [
       {
@@ -13,11 +17,14 @@
     ]
   },
   "include": [
-    "next-env.d.ts",
-    "next.config.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "next-env.d.ts",
+    "next.config.ts",
+    ".next-dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## What

Build improvements from the build-behavior analysis, in two stages:

### Stage 1 — make the existing build efficient

1. **Disk cache for registry indexes during build** (`lib/build-cache.ts`). Indexes over 2MB bypass Next's data cache, so every page of a large registry re-downloaded its index during static generation — Plate (2.24MB) was fetched **645×** per build with 17 timeouts; shadcn-ui-blocks (3.38MB) 20×. One download per index is now shared across all build workers via a file cache under `.next/cache/registry-index` (launcher-independent; Vercel persists it between builds, and a 60-minute TTL keeps the daily rebuild fresh). `registry-stats` and `registry-items` previously duplicated their own `registry.json` fetch — both now go through `fetchRegistryIndex` and inherit the cache.
2. **Parallel index fetching** in both `generateStaticParams` and the sitemap (`Promise.allSettled`, same pattern the home page already uses) instead of serial per-registry awaits.
3. **Separate dev/build output dirs** — `next dev` now writes `.next-dev`, so running a production build no longer corrupts a live dev server.

### Stage 2 — stop prebaking pages nobody visits

4. **Prerender only categories + featured; item long tail renders on demand.** 30 days of Web Analytics: ~340 distinct item pages got any human visit (122 of them exactly once), while landings + categories + featured cover ~86% of real traffic. The same categories+featured policy already applied to github-less handles now applies to every registry. The sitemap still lists the full catalog (24,599 URLs); un-prerendered pages fill via ISR on first request and stay cached until the daily rebuild.

## Measured (dev server running throughout)

| Build | Pages | Time | >2MB cache-bypass warnings | Timeouts |
|---|---|---|---|---|
| Before (baseline) | 19,403 | ~5–6 min | 665 | 17 |
| Stage 1, cold cache | 19,401 | 2:58 | 2 (initial downloads) | 0 |
| Stage 1, warm cache | 19,401 | 2:54 | 0 | 0 |
| **Stage 1 + 2** | **714** | **0:30** | 0 | 0 |

On-demand verified with `next start`: first request to an un-prerendered item 200 in 77ms (warm fetch cache; expect ~0.5–2s on a cold serverless hit), second request 7ms from ISR cache; unknown slugs still 404.

Build cost now scales with the number of registries (a few curated pages each), not with catalog size.