### PR TITLE
data: pro-chip audit corrections + Beste UI featured

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -707,8 +707,8 @@
         "pro_blocks": true,
         "templates": true,
         "figma_kit": false,
-        "mcp_agent": false,
-        "team_license": false
+        "mcp_agent": true,
+        "team_license": true
       }
     },
     {
@@ -913,6 +913,14 @@
       "github_url": "https://github.com/beste-co/beste-ui",
       "github_profile": "https://github.com/beste-co.png",
       "namespace": "@beste-ui",
+      "featured": [
+        "hero19",
+        "feature1",
+        "testimonial1",
+        "blog3",
+        "terminal1",
+        "cta8"
+      ],
       "pro": {
         "pro_blocks": true,
         "templates": false,
@@ -1058,7 +1066,7 @@
       ],
       "pro": {
         "pro_blocks": true,
-        "templates": false,
+        "templates": true,
         "figma_kit": true,
         "mcp_agent": true,
         "team_license": true


### PR DESCRIPTION
## What

Applies the results of a live-site audit of the 9 newest admissions (every chip verified against pricing pages/docs, evidence recorded):

**Chip corrections (3):**
- **ShadcnCraft** `templates: true` — /pricing sells "Pro Pages & Sites" (full Next.js sites, e.g. /sites/clearflow); /license includes Sites templates
- **shadcn-ui-blocks.com** `team_license: true` — /pricing FAQ: team plan covers 15 people with individual logins/API keys
- **shadcn-ui-blocks.com** `mcp_agent: true` — own hosted MCP server at /api/mcp (/docs/mcp), plus shadcn MCP docs

**Beste UI featured (first set):** `hero19`, `feature1`, `testimonial1`, `blog3`, `terminal1`, `cta8` — six distinct categories, each verified HTTP 200 with real file content on their endpoint. The original probe candidates all 404 (most of the 1,735-item catalog is pro-gated and masked as 404).

Everything else verified as already listed, including Turbopills with no `pro` object (nothing is sold around that library) and Zippystarter's featured staying as-is (its 4 components are the entire public catalog; themes/fonts have no files to render).

## Verified

- JSON parses; 74 entries unchanged in count
- Dev render: /beste-co/beste-ui landing shows all 6 featured; /beste-co/beste-ui/hero19 → 200