### PR TITLE
feat: aggregated dynamic-search endpoint at /r

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -7,6 +7,7 @@ import { DirectoryTabsSkeleton } from "@/components/directory-tabs-skeleton";
 import { fetchAllRegistryStats } from "@/lib/registry-stats";
 import { fetchAllGitHubStats } from "@/lib/github-stats";
 import { fetchAllRegistryItems } from "@/lib/registry-items";
+import { buildAndPersistCatalog } from "@/lib/catalog";
 import { getAffiliates } from "@/lib/affiliates";
 import { AffiliateDisclosure } from "@/components/affiliate-disclosure";
 import type { DirectoryEntry } from "@/lib/types";
@@ -94,6 +95,10 @@ export default async function Home() {
     fetchAllGitHubStats(components),
     fetchAllRegistryItems(components),
     getAffiliates(),
+    // Side effect only: writes the /r endpoint's aggregated catalog to
+    // blob during the daily build (no-op in dev). Same trigger point as
+    // the github.json cache above.
+    buildAndPersistCatalog(),
   ]);
   return (
     <main className="relative flex min-h-screen flex-col items-center justify-start pt-24 md:pt-32 pb-12 md:pb-20">

--- a/apps/web/app/r/[...path]/route.ts
+++ b/apps/web/app/r/[...path]/route.ts
@@ -19,9 +19,13 @@ export const dynamic = "force-dynamic"
 
 const DEFAULT_LIMIT = 100
 const MAX_LIMIT = 1000
+// Scoring cost is items × query terms; an unbounded q would let a single
+// request buy arbitrary CPU. 200 chars covers any real component search.
+const MAX_QUERY_LENGTH = 200
 
 const JSON_HEADERS = {
   "Content-Type": "application/json",
+  "X-Content-Type-Options": "nosniff",
   "Access-Control-Allow-Origin": "*",
   // Cached per full URL (query included) at the CDN; the daily rebuild
   // rewrites the blob, so stale answers converge within the hour.
@@ -70,7 +74,7 @@ function publicItem(item: CatalogItem) {
 
 function catalogResponse(catalog: Catalog, request: NextRequest): Response {
   const params = request.nextUrl.searchParams
-  const q = params.get("q")?.trim()
+  const q = params.get("q")?.trim().slice(0, MAX_QUERY_LENGTH)
   const typeParam = params.get("type")
   const hasSearchParams =
     params.has("q") || params.has("type") || params.has("limit") || params.has("offset")

--- a/apps/web/app/r/[...path]/route.ts
+++ b/apps/web/app/r/[...path]/route.ts
@@ -1,0 +1,196 @@
+import type { NextRequest } from "next/server"
+import { searchItems } from "@/lib/search-utils"
+import type { IndexedItem } from "@/lib/items-index"
+import { loadCatalog, type Catalog, type CatalogItem } from "@/lib/catalog"
+import { registryFetch } from "@/lib/fetch-utils"
+
+// Aggregated shadcn registry endpoint (dynamic search protocol):
+//
+//   GET /r/registry.json                → full catalog (static ingesters)
+//   GET /r/registry.json?q=&type=&limit=&offset= → server-side search with
+//       a pagination object; the shadcn CLI trusts our ranking end-to-end
+//   GET /r/{handle}/{item}.json         → item JSON proxied from the origin
+//       registry (the CLI resolves installs through the same namespace
+//       that answered the search)
+//
+// Configure as: "@registrydirectory": "https://registry.directory/r/{name}.json"
+
+export const dynamic = "force-dynamic"
+
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 1000
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json",
+  "Access-Control-Allow-Origin": "*",
+  // Cached per full URL (query included) at the CDN; the daily rebuild
+  // rewrites the blob, so stale answers converge within the hour.
+  "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+} as const
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS })
+}
+
+// searchItems scores IndexedItem.name — feed it the ORIGINAL item name so
+// exact matches keep their bonus, and carry the catalog item alongside.
+type SearchableItem = IndexedItem & { catalogItem: CatalogItem }
+
+const searchableCache = new WeakMap<Catalog, SearchableItem[]>()
+
+function searchables(catalog: Catalog): SearchableItem[] {
+  let list = searchableCache.get(catalog)
+  if (!list) {
+    list = catalog.items.map((item) => ({
+      name: item.name,
+      type: item.type,
+      description: item.description,
+      categories: item.categories,
+      registry: {
+        name: item.registryName,
+        basePath: `/${item.handle}`,
+        avatarUrl: null,
+      },
+      catalogItem: item,
+    }))
+    searchableCache.set(catalog, list)
+  }
+  return list
+}
+
+function publicItem(item: CatalogItem) {
+  return {
+    name: item.namespaced,
+    type: item.type,
+    description: item.description
+      ? `[${item.registryName}] ${item.description}`
+      : `[${item.registryName}]`,
+  }
+}
+
+function catalogResponse(catalog: Catalog, request: NextRequest): Response {
+  const params = request.nextUrl.searchParams
+  const q = params.get("q")?.trim()
+  const typeParam = params.get("type")
+  const hasSearchParams =
+    params.has("q") || params.has("type") || params.has("limit") || params.has("offset")
+
+  let results: CatalogItem[]
+  if (q) {
+    results = (searchItems(searchables(catalog), q) as SearchableItem[]).map(
+      (s) => s.catalogItem
+    )
+  } else {
+    results = catalog.items
+  }
+
+  if (typeParam) {
+    const types = new Set(
+      typeParam
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean)
+        .map((t) => (t.startsWith("registry:") ? t : `registry:${t}`))
+    )
+    results = results.filter((item) => types.has(item.type))
+  }
+
+  const limit = hasSearchParams
+    ? Math.min(Math.max(Number(params.get("limit")) || DEFAULT_LIMIT, 1), MAX_LIMIT)
+    : results.length
+  const offset = Math.max(Number(params.get("offset")) || 0, 0)
+  const page = results.slice(offset, offset + limit)
+
+  return jsonResponse({
+    $schema: "https://ui.shadcn.com/schema/registry.json",
+    name: "registry.directory",
+    homepage: "https://registry.directory",
+    items: page.map(publicItem),
+    pagination: {
+      total: results.length,
+      offset,
+      limit,
+      hasMore: offset + limit < results.length,
+    },
+  })
+}
+
+async function itemResponse(catalog: Catalog, namespaced: string): Promise<Response> {
+  const item = catalog.items.find((i) => i.namespaced === namespaced)
+  if (!item) {
+    return jsonResponse(
+      { error: `Item "${namespaced}" not found in the registry.directory catalog.` },
+      404
+    )
+  }
+
+  const registry = catalog.registries[item.handle]
+  if (!registry) {
+    return jsonResponse(
+      { error: `Origin registry for "${namespaced}" is not resolvable.` },
+      404
+    )
+  }
+  const originUrl = `${registry.itemBase}/${item.name}.json`
+
+  try {
+    const response = await registryFetch(originUrl, {
+      timeout: 10000,
+      next: { revalidate: 86400 },
+    })
+
+    if (!response.ok) {
+      const status = response.status === 404 ? 404 : 502
+      return jsonResponse(
+        {
+          error: `Origin registry "${item.registryName}" responded ${response.status} for "${item.name}".`,
+        },
+        status
+      )
+    }
+
+    const originItem = (await response.json()) as Record<string, unknown>
+    // Keep the identity the search result promised. registryDependencies
+    // pass through untouched: a plain dep name natively resolves to
+    // @shadcn, never to the origin registry — same semantics as a direct
+    // URL install.
+    originItem.name = namespaced
+    return jsonResponse(originItem)
+  } catch {
+    return jsonResponse(
+      { error: `Failed to reach origin registry "${item.registryName}".` },
+      502
+    )
+  }
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+): Promise<Response> {
+  const { path } = await params
+  const joined = path.join("/")
+
+  const catalog = await loadCatalog()
+  if (!catalog) {
+    return jsonResponse({ error: "Catalog unavailable, try again shortly." }, 503)
+  }
+
+  if (joined === "registry.json" || joined === "registry") {
+    return catalogResponse(catalog, request)
+  }
+
+  const namespaced = joined.replace(/\.json$/, "")
+  return itemResponse(catalog, namespaced)
+}
+
+export function OPTIONS(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    },
+  })
+}

--- a/apps/web/lib/build-cache.ts
+++ b/apps/web/lib/build-cache.ts
@@ -15,7 +15,7 @@ import { join } from "node:path"
 const CACHE_DIR = join(process.cwd(), ".next", "cache", "registry-index")
 const MAX_AGE_MS = 60 * 60 * 1000
 
-function isBuildPhase(): boolean {
+export function isBuildPhase(): boolean {
   return (
     process.env.NEXT_PHASE === "phase-production-build" ||
     process.env.NEXT_PHASE === "phase-export"

--- a/apps/web/lib/catalog.ts
+++ b/apps/web/lib/catalog.ts
@@ -1,0 +1,244 @@
+import { put } from "@vercel/blob"
+import type { DirectoryEntry } from "./types"
+import type { RegistryItem } from "./registry-types"
+import { registryFetch } from "./fetch-utils"
+import { isBuildPhase } from "./build-cache"
+import {
+  loadDirectory,
+  parseGithubRef,
+  entryHandle,
+  fetchRegistryIndex,
+} from "./resolve-registry"
+
+// Aggregated cross-registry catalog served at /r/registry.json (shadcn
+// dynamic search protocol) and backing the /r/{handle}/{item}.json proxy.
+//
+// Built once per daily build from the home page (blob write, same pattern
+// as github.json) and read at request time by the /r route handler.
+//
+// Fallback chain, mirroring github-stats.ts:
+// 1. Build with BLOB_READ_WRITE_TOKEN → catalog persisted to blob
+// 2. Runtime with blob → fetch once per instance, cache in memory (1h)
+// 3. Runtime without blob (local dev) → build in-process on first request
+
+const BLOB_FILENAME = "catalog.json"
+const MEMORY_TTL_MS = 60 * 60 * 1000
+const DESCRIPTION_MAX = 300
+
+export interface CatalogItem {
+  // Original item name at the origin registry — used for relevance
+  // scoring and to build the origin fetch URL.
+  name: string
+  // Public identity through the aggregator: "{handle}/{name}". This is
+  // what the CLI sees and what @namespace/{...} resolves to.
+  namespaced: string
+  type: string
+  description: string
+  categories: string[]
+  registryName: string
+  handle: string
+}
+
+export interface CatalogRegistry {
+  name: string
+  // Base URL for individual item JSONs at the origin: `${itemBase}/{name}.json`
+  itemBase: string
+}
+
+export interface Catalog {
+  generatedAt: string
+  registries: Record<string, CatalogRegistry>
+  items: CatalogItem[]
+}
+
+function itemBaseUrl(entry: DirectoryEntry): string {
+  if (entry.registry_url) {
+    return entry.registry_url.replace(/\/[^/]+\.json$/, "")
+  }
+  return `${entry.url.replace(/\/$/, "")}/r`
+}
+
+function catalogHandle(entry: DirectoryEntry): string | null {
+  const handle = entryHandle(entry)
+  if (handle) return handle.toLowerCase()
+  const gh = parseGithubRef(entry.github_url)
+  return gh ? gh.owner.toLowerCase() : null
+}
+
+// A registry whose sampled items all fail to resolve is fully gated (or
+// broken) — listing it would turn every install into our 502. Sampling
+// first/middle/last keeps partially-gated registries in.
+async function originResolves(
+  base: string,
+  names: string[]
+): Promise<boolean> {
+  const samples = Array.from(
+    new Set(
+      [names[0], names[Math.floor(names.length / 2)], names[names.length - 1]].filter(
+        (n): n is string => Boolean(n)
+      )
+    )
+  )
+
+  const results = await Promise.allSettled(
+    samples.map(async (name) => {
+      const res = await registryFetch(`${base}/${name}.json`, {
+        timeout: 5000,
+        cache: "no-store",
+      })
+      await res.body?.cancel()
+      return res.ok
+    })
+  )
+
+  return results.some((r) => r.status === "fulfilled" && r.value)
+}
+
+export async function buildCatalog(options?: {
+  probeOrigins?: boolean
+}): Promise<Catalog> {
+  const probeOrigins = options?.probeOrigins ?? true
+  const entries = await loadDirectory()
+
+  const registries: Record<string, CatalogRegistry> = {}
+  const items: CatalogItem[] = []
+
+  const results = await Promise.allSettled(
+    entries.map(async (entry) => {
+      const handle = catalogHandle(entry)
+      if (!handle) return null
+
+      const index = await fetchRegistryIndex(entry, 10000)
+      if (!index?.items?.length) return null
+
+      const base = itemBaseUrl(entry)
+      const names = index.items.map((i) => i.name)
+
+      if (probeOrigins && !(await originResolves(base, names))) {
+        console.log(
+          `[catalog] Excluding ${entry.name}: sampled items do not resolve at ${base}`
+        )
+        return null
+      }
+
+      const seen = new Set<string>()
+      const registryItems: CatalogItem[] = []
+      for (const item of index.items as RegistryItem[]) {
+        if (seen.has(item.name)) continue
+        seen.add(item.name)
+        registryItems.push({
+          name: item.name,
+          namespaced: `${handle}/${item.name}`,
+          type: item.type || "registry:item",
+          description: (item.description || "").slice(0, DESCRIPTION_MAX),
+          categories: item.categories || [],
+          registryName: entry.name,
+          handle,
+        })
+      }
+
+      return { handle, registry: { name: entry.name, itemBase: base }, registryItems }
+    })
+  )
+
+  for (const result of results) {
+    if (result.status !== "fulfilled" || !result.value) continue
+    const { handle, registry, registryItems } = result.value
+    if (registries[handle]) {
+      console.log(`[catalog] Duplicate handle ${handle}, keeping first`)
+      continue
+    }
+    registries[handle] = registry
+    items.push(...registryItems)
+  }
+
+  console.log(
+    `[catalog] Built ${items.length} items from ${Object.keys(registries).length} registries`
+  )
+
+  return { generatedAt: new Date().toISOString(), registries, items }
+}
+
+export async function persistCatalog(catalog: Catalog): Promise<void> {
+  const blobToken = process.env.BLOB_READ_WRITE_TOKEN
+  if (!blobToken) return
+
+  try {
+    await put(BLOB_FILENAME, JSON.stringify(catalog), {
+      access: "public",
+      token: blobToken,
+      addRandomSuffix: false,
+      allowOverwrite: true,
+    })
+    console.log(`[catalog] Wrote catalog to blob (${catalog.items.length} items)`)
+  } catch (error) {
+    console.error("[catalog] Failed to write blob:", error)
+  }
+}
+
+// Called from the home page's build render (same trigger as github.json).
+// No-ops outside the build phase so dev renders stay cheap, and without a
+// blob token so forks degrade gracefully.
+export async function buildAndPersistCatalog(): Promise<void> {
+  if (!isBuildPhase()) return
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    console.log("[catalog] No BLOB_READ_WRITE_TOKEN, skipping catalog persist")
+    return
+  }
+
+  try {
+    const catalog = await buildCatalog()
+    if (catalog.items.length > 0) {
+      await persistCatalog(catalog)
+    }
+  } catch (error) {
+    console.error("[catalog] Build-time persist failed:", error)
+  }
+}
+
+async function readCatalogBlob(): Promise<Catalog | null> {
+  const blobToken = process.env.BLOB_READ_WRITE_TOKEN
+  if (!blobToken) return null
+
+  try {
+    const storeMatch = blobToken.match(/vercel_blob_rw_([^_]+)_/)
+    if (!storeMatch) return null
+
+    const blobUrl = `https://${storeMatch[1]}.public.blob.vercel-storage.com/${BLOB_FILENAME}`
+    // The catalog is several MB — over Next's data-cache limit — so skip
+    // the data cache explicitly; the in-memory cache below absorbs the cost.
+    const response = await fetch(blobUrl, { cache: "no-store" })
+    if (!response.ok) return null
+
+    return (await response.json()) as Catalog
+  } catch {
+    return null
+  }
+}
+
+let memory: { catalog: Catalog; at: number } | null = null
+
+export async function loadCatalog(): Promise<Catalog | null> {
+  if (memory && Date.now() - memory.at < MEMORY_TTL_MS) {
+    return memory.catalog
+  }
+
+  let catalog = await readCatalogBlob()
+
+  if (!catalog) {
+    // Local dev without blob: build in-process (skip origin probes — they
+    // are a build-time quality gate, not worth 200 requests per dev reload).
+    console.log("[catalog] No blob available, building catalog in-process")
+    try {
+      catalog = await buildCatalog({ probeOrigins: false })
+    } catch (error) {
+      console.error("[catalog] In-process build failed:", error)
+      return memory?.catalog ?? null
+    }
+  }
+
+  if (!catalog.items.length) return memory?.catalog ?? null
+
+  memory = { catalog, at: Date.now() }
+  return catalog
+}

--- a/apps/web/lib/resolve-registry.ts
+++ b/apps/web/lib/resolve-registry.ts
@@ -62,6 +62,43 @@ export async function resolveByHandle(
   )
 }
 
+// shadcn dynamic search (jul 2026): a registry may answer the bare GET with
+// a partial page plus a pagination object. Without this loop we would
+// silently index 50 items instead of the full catalog.
+type PaginatedRegistry = Registry & {
+  pagination?: { total: number; offset: number; limit: number; hasMore: boolean }
+}
+
+const MAX_PAGINATION_PAGES = 100
+
+async function fetchRemainingPages(
+  targetUrl: string,
+  first: PaginatedRegistry,
+  timeout: number
+): Promise<Registry> {
+  const items = [...first.items]
+  const pageSize = first.pagination?.limit || items.length || 100
+
+  for (let page = 0; page < MAX_PAGINATION_PAGES; page++) {
+    const url = new URL(targetUrl)
+    url.searchParams.set("limit", String(pageSize))
+    url.searchParams.set("offset", String(items.length))
+
+    const response = await registryFetch(url.toString(), {
+      timeout,
+      next: { revalidate: 86400 },
+    })
+    if (!response.ok) break
+
+    const next = (await response.json()) as PaginatedRegistry
+    if (!next.items?.length) break
+    items.push(...next.items)
+    if (!next.pagination?.hasMore) break
+  }
+
+  return { ...first, items }
+}
+
 export async function fetchRegistryIndex(
   entry: DirectoryEntry,
   timeout = 5000
@@ -78,7 +115,13 @@ export async function fetchRegistryIndex(
       next: { revalidate: 86400 },
     })
     if (!response.ok) return null
-    const data = (await response.json()) as Registry
+    let data = (await response.json()) as PaginatedRegistry
+    if (data.pagination?.hasMore) {
+      console.log(
+        `[Registry] ${entry.name} paginates its index (${data.items.length}/${data.pagination.total}), fetching remaining pages`
+      )
+      data = await fetchRemainingPages(targetUrl, data, timeout)
+    }
     await writeCachedJson(targetUrl, data)
     return data
   } catch (error) {


### PR DESCRIPTION
## Summary

registry.directory now speaks [shadcn's dynamic search protocol](https://ui.shadcn.com/docs/registry/dynamic-search) over the cross-registry index — ~24.5k items from 69 registries, searchable and installable from the shadcn CLI and any agent using shadcn's MCP:

```json
// components.json
"registries": { "@registrydirectory": "https://registry.directory/r/{name}.json" }
```

```bash
shadcn search @registrydirectory -q "animated button"   # server-ranked, cross-registry
shadcn add @registrydirectory/magicui/pulsating-button   # installs through the proxy
```

## What's included

- **`GET /r/registry.json`** — full aggregated catalog (static ingesters, official-index requirement)
- **`GET /r/registry.json?q=&type=&limit=&offset=`** — server-side search with a `pagination` object; the CLI trusts our ranking end-to-end (same `searchItems` scoring as the home search, plus round-robin interleaving across registries)
- **`GET /r/{handle}/{item}.json`** — item JSON proxied from the origin registry (24h cache, identity rewritten to the namespaced name, `registryDependencies` untouched to preserve native @shadcn semantics)
- **Catalog pipeline** — built during the daily build, persisted to Vercel Blob (`catalog.json`, same pattern as `github.json`); runtime falls back to an in-process build without blob. Registries whose sampled items all fail to resolve are excluded rather than turned into our 502s.
- **Ingestion armor** — `fetchRegistryIndex` now follows paginated indexes (`pagination.hasMore`), so a registry adopting dynamic search with paginated-by-default responses can no longer silently shrink our index to its first page.
- **Input hardening** — `q` capped at 200 chars (scoring cost is items × terms), `limit` clamped 1–1000, `nosniff`, CORS read-only. No SSRF surface: the request path selects catalog items, it never builds origin URLs.

## Verification

E2E against shadcn CLI 4.16.1 on a `next start` production build: search (query, multi-term, type filter, offset pagination, `--json`), add with cssVars merge, add with transitive dependencies (button/card resolved from ui.shadcn.com), honest 404s, bare-GET full catalog. Search latency 8–13ms warm, item proxy 3.5ms warm. Home page build output unchanged (714 pages); the frontend search path is untouched.