### PR TITLE
fix: probe resilience, Aceternity registry_url, MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ronny Badilla
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/web/lib/catalog.ts
+++ b/apps/web/lib/catalog.ts
@@ -68,6 +68,13 @@ function catalogHandle(entry: DirectoryEntry): string | null {
 // A registry whose sampled items all fail to resolve is fully gated (or
 // broken) — listing it would turn every install into our 502. Sampling
 // first/middle/last keeps partially-gated registries in.
+//
+// Exclusion requires DEFINITIVE gating (401/402/403/404/410) on every
+// sample. Transient failures — 429 rate limits, 5xx, timeouts — get the
+// benefit of the doubt: a registry throttling our build burst must not
+// drop out of the catalog (Cult UI, 31-jul-2026).
+const GATED_STATUSES = new Set([401, 402, 403, 404, 410])
+
 async function originResolves(
   base: string,
   names: string[]
@@ -87,11 +94,24 @@ async function originResolves(
         cache: "no-store",
       })
       await res.body?.cancel()
-      return res.ok
+      return res.status
     })
   )
 
-  return results.some((r) => r.status === "fulfilled" && r.value)
+  let allGated = results.length > 0
+  for (const result of results) {
+    if (
+      result.status === "fulfilled" &&
+      result.value >= 200 &&
+      result.value < 300
+    ) {
+      return true
+    }
+    const gated =
+      result.status === "fulfilled" && GATED_STATUSES.has(result.value)
+    if (!gated) allGated = false
+  }
+  return !allGated
 }
 
 export async function buildCatalog(options?: {

--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -635,7 +635,7 @@
         "globe",
         "bento-grid"
       ],
-      "registry_url": "https://ui.aceternity.com/registry.json"
+      "registry_url": "https://ui.aceternity.com/registry/registry.json"
     },
     {
       "name": "SMUI",


### PR DESCRIPTION
Three small fixes surfaced by the first production build of the /r catalog:

- **Probe resilience** — the origin-resolution probe now excludes a registry only on definitive gating (401/402/403/404/410 on every sample). Transient failures (429 rate limits, 5xx, timeouts) get the benefit of the doubt: Cult UI was dropped from the catalog because it throttled our build burst.
- **Aceternity registry_url** — items live at `ui.aceternity.com/registry/{name}.json`; the old URL derived item fetches at the domain root, silently breaking both the IDE viewer and the /r item proxy for every Aceternity item.
- **MIT license** — the repo was public without a license; MIT aligns with the shadcn registry directory requirements ahead of the @registrydirectory listing PR.

After merge, the next daily build should restore Aceternity and Cult UI to the aggregated catalog (~64 → ~66 registries).