### PR TITLE
feat: CLI-first hero — the command is the tagline

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -21,9 +21,9 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://registry.directory"),
   title: {
     template: "%s | registry.directory",
-    default: "registry.directory - The explorer for shadcn/ui registries",
+    default: "registry.directory - The explorer for the shadcn registry ecosystem",
   },
-  description: "Browse, preview, and install from any shadcn/ui registry. Explore components in an IDE viewer, then copy the install command.",
+  description: "Search and install from every shadcn registry with one CLI namespace — @registrydirectory. Or browse components in the IDE viewer and copy the install command.",
 };
 
 export const viewport: Viewport = {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -8,6 +8,7 @@ import { fetchAllRegistryStats } from "@/lib/registry-stats";
 import { fetchAllGitHubStats } from "@/lib/github-stats";
 import { fetchAllRegistryItems } from "@/lib/registry-items";
 import { buildAndPersistCatalog } from "@/lib/catalog";
+import { CliHero } from "@/components/cli-hero";
 import { getAffiliates } from "@/lib/affiliates";
 import { AffiliateDisclosure } from "@/components/affiliate-disclosure";
 import type { DirectoryEntry } from "@/lib/types";
@@ -110,34 +111,7 @@ export default async function Home() {
         <HeroTitle />
       </div>
 
-      <p className="text-sm mb-12 md:mb-14 px-4 text-center font-mono text-muted-foreground">
-        The explorer for{" "}
-        <span className="text-foreground">
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            className="inline-flex size-4 text-muted-foreground"
-          >
-            <path
-              d="M21.0001 12.4286L12.4287 21"
-              stroke="currentColor"
-              strokeWidth="3"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            ></path>
-            <path
-              d="M19.2857 3L3 19.2857"
-              stroke="currentColor"
-              strokeWidth="3"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            ></path>
-          </svg>
-        </span>
-        <span className="ml-1 font-mono font-bold">shadcn/ui</span>
-        <span className="text-muted-foreground"> registries.</span>
-      </p>
+      <CliHero />
 
       <Suspense fallback={<DirectoryTabsSkeleton />}>
         <DirectoryTabs components={components} stats={stats} githubStats={githubStats} items={items} affiliates={affiliates} />

--- a/apps/web/components/cli-hero.tsx
+++ b/apps/web/components/cli-hero.tsx
@@ -4,7 +4,7 @@ import { useState } from "react"
 import { Check, Copy } from "lucide-react"
 import { useAnalytics } from "@/hooks/use-analytics"
 
-const CLI_COMMAND = 'npx shadcn@latest search @registrydirectory -q "button"'
+const CLI_COMMAND = 'npx shadcn search @registrydirectory -q "button"'
 
 // The command IS the tagline: the CLI is the primary way in, the site
 // below the "or" separator is the alternative.
@@ -20,7 +20,7 @@ export function CliHero() {
   }
 
   return (
-    <div className="flex flex-col items-center w-full px-4 mb-12 md:mb-14">
+    <div className="flex flex-col items-center w-full px-4 mb-8">
       <button
         type="button"
         onClick={handleCopy}
@@ -29,7 +29,7 @@ export function CliHero() {
       >
         <span className="overflow-x-auto whitespace-nowrap text-left [scrollbar-width:none]">
           <span className="select-none text-muted-foreground">$ </span>
-          <span className="text-muted-foreground">npx shadcn@latest search </span>
+          <span className="text-muted-foreground">npx shadcn search </span>
           <span className="font-semibold text-foreground">@registrydirectory</span>
           <span className="text-muted-foreground"> -q </span>
           <span className="text-foreground">&quot;button&quot;</span>

--- a/apps/web/components/cli-hero.tsx
+++ b/apps/web/components/cli-hero.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { useState } from "react"
+import { Check, Copy } from "lucide-react"
+import { useAnalytics } from "@/hooks/use-analytics"
+
+const CLI_COMMAND = 'npx shadcn@latest search @registrydirectory -q "button"'
+
+// The command IS the tagline: the CLI is the primary way in, the site
+// below the "or" separator is the alternative.
+export function CliHero() {
+  const [copied, setCopied] = useState(false)
+  const analytics = useAnalytics()
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(CLI_COMMAND)
+    setCopied(true)
+    analytics.trackCliCopied()
+    setTimeout(() => setCopied(false), 1200)
+  }
+
+  return (
+    <div className="flex flex-col items-center w-full px-4 mb-12 md:mb-14">
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label="Copy CLI command"
+        className="group flex max-w-full items-center gap-2.5 rounded-lg border border-border bg-muted/40 px-4 py-2.5 font-mono text-xs sm:text-sm transition-colors hover:border-muted-foreground/40"
+      >
+        <span className="overflow-x-auto whitespace-nowrap text-left [scrollbar-width:none]">
+          <span className="select-none text-muted-foreground">$ </span>
+          <span className="text-muted-foreground">npx shadcn@latest search </span>
+          <span className="font-semibold text-foreground">@registrydirectory</span>
+          <span className="text-muted-foreground"> -q </span>
+          <span className="text-foreground">&quot;button&quot;</span>
+        </span>
+        <span className="shrink-0 text-muted-foreground transition-colors group-hover:text-foreground">
+          {copied ? (
+            <Check className="size-3.5" aria-hidden="true" />
+          ) : (
+            <Copy className="size-3.5" aria-hidden="true" />
+          )}
+        </span>
+      </button>
+
+      <div
+        className="mt-8 flex w-full max-w-[220px] items-center gap-3"
+        aria-hidden="true"
+      >
+        <span className="h-px flex-1 bg-gradient-to-r from-transparent to-border" />
+        <span className="select-none font-mono text-[11px] text-muted-foreground/80">
+          or
+        </span>
+        <span className="h-px flex-1 bg-gradient-to-l from-transparent to-border" />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/hooks/use-analytics.ts
+++ b/apps/web/hooks/use-analytics.ts
@@ -213,6 +213,10 @@ export function useAnalytics() {
     [analytics, context]
   );
 
+  const trackCliCopied = useCallback(() => {
+    analytics.trackCliCopied(context);
+  }, [analytics, context]);
+
   // Debounced tracking methods for high-frequency events
   const trackSearchUsedDebounced = useMemo(
     () => debounce(trackSearchUsed, 500),
@@ -250,6 +254,9 @@ export function useAnalytics() {
     // Home discovery
     trackPremiumToggled,
     trackHomeRegistryVisit,
+
+    // CLI adoption
+    trackCliCopied,
 
     // Debounced methods
     trackSearchUsed: trackSearchUsedDebounced,

--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -155,6 +155,9 @@ export const ANALYTICS_EVENTS = {
   // Home discovery
   HOME_PREMIUM_TOGGLED: "home.premium.toggled",
   HOME_REGISTRY_VISIT: "home.registry.visit",
+
+  // CLI adoption
+  HOME_CLI_COPIED: "home.cli.copied",
 } as const;
 
 // ============================================================================
@@ -344,6 +347,10 @@ class Analytics {
 
   trackHomeRegistryVisit(properties: HomeRegistryVisitProperties & Partial<BaseEventProperties>): void {
     this.#trackEvent(ANALYTICS_EVENTS.HOME_REGISTRY_VISIT, properties);
+  }
+
+  trackCliCopied(properties: Partial<BaseEventProperties> = {}): void {
+    this.#trackEvent(ANALYTICS_EVENTS.HOME_CLI_COPIED, properties);
   }
 }
 


### PR DESCRIPTION
## Summary

The hero tagline becomes the CLI command. "The explorer for shadcn/ui registries" is replaced by a copyable `npx shadcn search @registrydirectory -q "button"` with an *or* separator below — the CLI is the primary way in, the site below is the alternative.

- Whole command is a copy button (copy → check feedback), instrumented as `home.cli.copied`
- `@registrydirectory` in semibold foreground, the rest muted — hierarchy without shouting
- Separator: 1px gradient lines fading outward, mono `or`, symmetric 32px spacing above and below
- Metadata follows the new identity: title "The explorer for the shadcn registry ecosystem", description leads with the CLI namespace (description is not a ranking factor; deep-page titles are untouched)

## Hold

**Do not merge until shadcn-ui/ui#11357 lands** — the displayed command works zero-config only once `@registrydirectory` is in the official registries index. Same-day sequence: their merge → this merge → announcement.