### PR TITLE
design: Schibsted Grotesk + IBM Plex Mono, typography audit fixes

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,18 +1,18 @@
 import type { Metadata, Viewport } from "next";
-import { DM_Sans, Geist_Mono } from "next/font/google"
+import { Schibsted_Grotesk, IBM_Plex_Mono } from "next/font/google"
 import { Analytics } from "@vercel/analytics/next"
 
 import "@workspace/ui/globals.css"
 import { Providers } from "@/components/providers"
 import { FeedbackWidget } from "@/components/feedback-widget"
 
-const dmSans = DM_Sans({
-  variable: "--font-dm-sans",
+const schibsted = Schibsted_Grotesk({
+  variable: "--font-schibsted",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const ibmPlexMono = IBM_Plex_Mono({
+  variable: "--font-ibm-plex-mono",
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
 });
@@ -45,7 +45,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${dmSans.variable} ${geistMono.variable} font-sans antialiased`}
+        className={`${schibsted.variable} ${ibmPlexMono.variable} font-sans antialiased`}
       >
         <Providers>
           {children}

--- a/apps/web/components/directory-list.tsx
+++ b/apps/web/components/directory-list.tsx
@@ -151,7 +151,7 @@ export function DirectoryList({ entries, searchTerm = '', addCardLabel, showView
                 </div>
               </CardHeader>
               <CardContent className="px-3 pb-3 pt-0 bg-background flex-1 flex flex-col justify-between">
-                <CardDescription className="text-[13px] text-foreground-secondary line-clamp-2">
+                <CardDescription className="text-[13px] text-foreground-secondary line-clamp-2 text-pretty">
                   {entry.description}
                 </CardDescription>
                 {(gh || s) && (
@@ -271,7 +271,7 @@ function ItemResults({ items, onResultClick }: { items: IndexedItem[]; onResultC
                   </CardHeader>
                   <CardContent className="px-3 pb-3 pt-0 bg-background flex-1">
                     {item.description && (
-                      <CardDescription className="text-[13px] text-foreground-secondary line-clamp-2">
+                      <CardDescription className="text-[13px] text-foreground-secondary line-clamp-2 text-pretty">
                         {item.description}
                       </CardDescription>
                     )}

--- a/apps/web/components/registry-landing/landing-hero.tsx
+++ b/apps/web/components/registry-landing/landing-hero.tsx
@@ -34,7 +34,7 @@ export function LandingHero({
           />
         )}
         <div className="flex min-w-0 flex-col gap-0.5">
-          <h1 className="text-2xl font-semibold tracking-tight text-foreground md:text-[28px] md:leading-9">
+          <h1 className="text-2xl font-semibold tracking-tight text-balance text-foreground md:text-[28px] md:leading-9">
             {registry.name}
           </h1>
           <p className="truncate font-mono text-xs">
@@ -45,7 +45,7 @@ export function LandingHero({
       </div>
 
       {registry.description && (
-        <p className="max-w-[520px] text-base leading-relaxed text-muted-foreground">
+        <p className="max-w-[520px] text-base leading-relaxed text-pretty text-muted-foreground">
           {registry.description}
         </p>
       )}

--- a/apps/web/components/search-bar.tsx
+++ b/apps/web/components/search-bar.tsx
@@ -25,7 +25,7 @@ export function SearchBar({ value, onChange, placeholder = "Search registries an
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
           aria-label={placeholder}
-          className={`w-full pr-10 bg-background border border-input rounded-none text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground outline-none transition-[color,box-shadow] font-mono focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 ${large ? "pl-12 py-3.5 text-base" : "pl-10 py-2 text-sm"}`}
+          className={`w-full pr-10 bg-background border border-input rounded-none text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground outline-none transition-[color,box-shadow] font-mono focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 ${large ? "pl-12 py-3.5 text-base sm:py-4 sm:text-sm" : "pl-10 py-2 text-sm"}`}
           autoComplete="off"
           spellCheck="false"
         />

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -93,8 +93,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-dm-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-schibsted);
+  --font-mono: var(--font-ibm-plex-mono);
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
   --color-popover: var(--popover);
@@ -150,5 +150,7 @@
     @apply bg-background text-foreground;
     font-feature-settings: "rlig" 0, "calt" 0;
     text-rendering: optimizeLegibility;
+    /* Missing weights/styles must fail visibly, not render browser-faked */
+    font-synthesis: none;
   }
 }


### PR DESCRIPTION
## Summary

New type pairing, adopted from rbadillap's personal identity and adapted to the product:

- **Schibsted Grotesk** replaces DM Sans — grotesk skeleton coheres with the mono voice; editorial character for the curator side of the UI
- **IBM Plex Mono** replaces Geist Mono — the favicon was already set in Plex, so the mark and the interface now share one mono

Plus the actionable findings from a `better-typography` audit:

- `font-synthesis: none` — missing weights now fail visibly instead of rendering browser-faked bolds
- Search input drops to 14px on desktop matching the filter tabs (16px stays on mobile — iOS Safari zooms the page on inputs under 16px); height compensated, unchanged
- `text-pretty` on card/landing descriptions (no orphan words), `text-balance` on landing titles

Audit verdict worth recording: the site was already disciplined — all 18 uppercase uses carry positive tracking, tabular-nums where numbers live, styled selection. Parked as future chores: consolidating 16 arbitrary 11/13px sizes into the scale, and a contrast pass on the 10px muted hints.