### PR TITLE
feat(seo): structured data, richer metadata, and title vocabulary that matches search

### DIFF
--- a/apps/web/app/(app)/[owner]/[repo]/page.tsx
+++ b/apps/web/app/(app)/[owner]/[repo]/page.tsx
@@ -16,6 +16,12 @@ import {
   RegistrySlugView,
   buildSlugMetadata,
 } from "@/components/registry-slug-view"
+import { JsonLd } from "@/components/json-ld"
+import {
+  buildBreadcrumbSchema,
+  buildRegistryCollectionSchema,
+} from "@/lib/structured-data"
+import { SITE_NAME, TWITTER_HANDLE, shadcnQualifier } from "@/lib/seo"
 
 export async function generateMetadata({
   params,
@@ -31,20 +37,34 @@ export async function generateMetadata({
     const itemCount = index?.items?.length || 0
     const canonical = `https://registry.directory/${owner}/${repo}`
 
+    // Qualify the bare registry name with what it is and how many pieces it
+    // ships — "acme" alone matches nothing, "acme — 42 shadcn/ui components"
+    // matches the way people actually phrase the search.
+    const qualifier = shadcnQualifier(ghRegistry.name)
+    const title = itemCount
+      ? `${ghRegistry.name} — ${itemCount} ${qualifier}components & blocks`
+      : `${ghRegistry.name} — ${qualifier}registry`
+    const description =
+      ghRegistry.description ||
+      `Browse ${itemCount} shadcn/ui components from ${ghRegistry.name}. Preview the source in an IDE viewer and install with the shadcn CLI.`
+
     return {
-      title: ghRegistry.name,
-      description: ghRegistry.description || `Browse ${itemCount} components from ${ghRegistry.name}. Preview code in our IDE viewer and install with one command.`,
+      title,
+      description,
       alternates: { canonical },
       openGraph: {
-        title: ghRegistry.name,
-        description: ghRegistry.description || `Browse ${itemCount} components from ${ghRegistry.name}.`,
+        title,
+        description,
         url: canonical,
+        siteName: SITE_NAME,
+        locale: 'en_US',
         type: 'website',
       },
       twitter: {
         card: 'summary_large_image',
-        title: ghRegistry.name,
-        description: ghRegistry.description || `Browse ${itemCount} components from ${ghRegistry.name}.`,
+        site: TWITTER_HANDLE,
+        title,
+        description,
       },
     }
   }
@@ -116,13 +136,32 @@ export default async function RegistryLandingPage({
   // 1) Canonical github pair — always wins
   const ghRegistry = await resolveByGithub(owner, repo)
   if (ghRegistry) {
+    const basePath = `/${owner}/${repo}`
     const landingData = await loadLandingData(ghRegistry)
+    const index = await fetchRegistryIndex(ghRegistry)
+    const items = index?.items ?? []
+
     return (
-      <RegistryLanding
-        registry={ghRegistry}
-        basePath={`/${owner}/${repo}`}
-        {...landingData}
-      />
+      <>
+        <JsonLd
+          data={[
+            buildBreadcrumbSchema([
+              { name: ghRegistry.name, path: basePath },
+            ]),
+            buildRegistryCollectionSchema({
+              registry: ghRegistry,
+              basePath,
+              itemNames: items.map((item) => item.name),
+              totalItems: items.length,
+            }),
+          ]}
+        />
+        <RegistryLanding
+          registry={ghRegistry}
+          basePath={basePath}
+          {...landingData}
+        />
+      </>
     )
   }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,20 @@ import { Analytics } from "@vercel/analytics/next"
 import "@workspace/ui/globals.css"
 import { Providers } from "@/components/providers"
 import { FeedbackWidget } from "@/components/feedback-widget"
+import { JsonLd } from "@/components/json-ld"
+import {
+  buildOrganizationSchema,
+  buildWebSiteSchema,
+} from "@/lib/structured-data"
+import {
+  SITE_AUTHOR,
+  SITE_DESCRIPTION,
+  SITE_KEYWORDS,
+  SITE_NAME,
+  SITE_TAGLINE,
+  SITE_URL,
+  TWITTER_HANDLE,
+} from "@/lib/seo"
 
 const schibsted = Schibsted_Grotesk({
   variable: "--font-schibsted",
@@ -18,12 +32,52 @@ const ibmPlexMono = IBM_Plex_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://registry.directory"),
+  metadataBase: new URL(SITE_URL),
   title: {
-    template: "%s | registry.directory",
-    default: "registry.directory - The explorer for shadcn/ui registries",
+    // Brand last: the leading slot is worth more spent on what the page is
+    // than on a domain searchers only type once they already know us.
+    template: `%s | ${SITE_NAME}`,
+    default: `${SITE_NAME} — ${SITE_TAGLINE}`,
   },
-  description: "Browse, preview, and install from any shadcn/ui registry. Explore components in an IDE viewer, then copy the install command.",
+  description: SITE_DESCRIPTION,
+  applicationName: SITE_NAME,
+  authors: [SITE_AUTHOR],
+  creator: SITE_AUTHOR.name,
+  publisher: SITE_NAME,
+  keywords: SITE_KEYWORDS,
+  category: "technology",
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    locale: "en_US",
+    title: `${SITE_NAME} — ${SITE_TAGLINE}`,
+    description: SITE_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: TWITTER_HANDLE,
+    creator: TWITTER_HANDLE,
+    title: `${SITE_NAME} — ${SITE_TAGLINE}`,
+    description: SITE_DESCRIPTION,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
+  formatDetection: {
+    telephone: false,
+  },
 };
 
 export const viewport: Viewport = {
@@ -47,6 +101,9 @@ export default function RootLayout({
       <body
         className={`${schibsted.variable} ${ibmPlexMono.variable} font-sans antialiased`}
       >
+        {/* Site-wide identity nodes. Every other route emits page-scoped
+            schema that references these two by @id. */}
+        <JsonLd data={[buildWebSiteSchema(), buildOrganizationSchema()]} />
         <Providers>
           {children}
         </Providers>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -13,28 +13,48 @@ import { AffiliateDisclosure } from "@/components/affiliate-disclosure";
 import type { DirectoryEntry } from "@/lib/types";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { HeroTitle } from "@/components/hero-title";
+import { JsonLd } from "@/components/json-ld";
+import { buildDirectoryListSchema } from "@/lib/structured-data";
+import { registryBasePath } from "@/lib/resolve-registry";
+import {
+  SITE_DESCRIPTION,
+  SITE_KEYWORDS,
+  SITE_NAME,
+  SITE_TAGLINE,
+  SITE_URL,
+  TWITTER_HANDLE,
+} from "@/lib/seo";
 
 // Enable static generation
 export const dynamic = 'force-static'
 
+// The home title leads with the artefact nouns people actually search
+// ("registries, components, blocks") rather than with "explorer", which
+// describes the product but matches no query.
+const HOME_TITLE = `${SITE_NAME} — ${SITE_TAGLINE}`
+
 export const metadata: Metadata = {
-  metadataBase: new URL("https://registry.directory"),
-  title: "registry.directory - The explorer for shadcn/ui registries",
-  description:
-    "Browse, preview, and install from any shadcn/ui registry. Explore components in an IDE viewer, then copy the install command.",
+  metadataBase: new URL(SITE_URL),
+  title: HOME_TITLE,
+  description: SITE_DESCRIPTION,
+  keywords: SITE_KEYWORDS,
   alternates: {
-    canonical: "https://registry.directory",
+    canonical: SITE_URL,
   },
   openGraph: {
-    title: "registry.directory - The explorer for shadcn/ui registries",
-    description: "Browse, preview, and install from any shadcn/ui registry. Explore components in an IDE viewer, then copy the install command.",
-    url: "https://registry.directory",
+    title: HOME_TITLE,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    locale: "en_US",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "registry.directory - The explorer for shadcn/ui registries",
-    description: "Browse, preview, and install from any shadcn/ui registry. Explore components in an IDE viewer, then copy the install command.",
+    site: TWITTER_HANDLE,
+    creator: TWITTER_HANDLE,
+    title: HOME_TITLE,
+    description: SITE_DESCRIPTION,
   },
 };
 
@@ -100,8 +120,19 @@ export default async function Home() {
     // the github.json cache above.
     buildAndPersistCatalog(),
   ]);
+  const directorySchema = buildDirectoryListSchema(
+    components.flatMap((registry) => {
+      const path = registryBasePath(registry);
+      if (!path) return [];
+      return [
+        { name: registry.name, description: registry.description, path },
+      ];
+    })
+  );
+
   return (
     <main className="relative flex min-h-screen flex-col items-center justify-start pt-24 md:pt-32 pb-12 md:pb-20">
+      <JsonLd data={directorySchema} />
       <div className="absolute top-4 right-4">
         <ThemeToggle />
       </div>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -142,7 +142,7 @@ export default async function Home() {
       </div>
 
       <p className="text-sm mb-12 md:mb-14 px-4 text-center font-mono text-muted-foreground">
-        The explorer for{" "}
+        The explorer for the{" "}
         <span className="text-foreground">
           <svg
             viewBox="0 0 24 24"
@@ -166,8 +166,8 @@ export default async function Home() {
             ></path>
           </svg>
         </span>
-        <span className="ml-1 font-mono font-bold">shadcn/ui</span>
-        <span className="text-muted-foreground"> registries.</span>
+        <span className="ml-1 font-mono font-bold">shadcn</span>
+        <span className="text-muted-foreground"> registry ecosystem.</span>
       </p>
 
       <Suspense fallback={<DirectoryTabsSkeleton />}>

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -5,21 +5,34 @@ import {
   registryBasePath,
   fetchRegistryIndex,
 } from "@/lib/resolve-registry"
+import { fetchAllGitHubStats } from "@/lib/github-stats"
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://registry.directory'
   const entries: MetadataRoute.Sitemap = []
 
+  // One timestamp for the whole build. Stamping `new Date()` per entry told
+  // crawlers every URL in the directory changed on every daily rebuild, which
+  // is how a sitemap teaches Google to stop trusting its own lastmod. The
+  // home page genuinely does change each rebuild — the item pages below only
+  // claim a date when their registry gives us one.
+  const builtAt = new Date()
+
   // Homepage
   entries.push({
     url: baseUrl,
-    lastModified: new Date(),
+    lastModified: builtAt,
     changeFrequency: 'weekly',
     priority: 1,
   })
 
   try {
     const registries = await loadDirectory()
+
+    // Real lastmod for registry landings: the upstream repo's last push, read
+    // from the same cached github.json the home page already builds against.
+    // Empty when GITHUB_TOKEN is absent, which just means we omit the hint.
+    const githubStats = await fetchAllGitHubStats(registries)
 
     const perRegistry = await Promise.allSettled(
       registries.map(async (registry): Promise<MetadataRoute.Sitemap> => {
@@ -29,11 +42,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         const basePath = registryBasePath(registry)
         if (!basePath) return []
 
+        const lastCommit = registry.github_url
+          ? githubStats[registry.github_url]?.lastCommit
+          : undefined
+
         // Registry overview page
         const urls: MetadataRoute.Sitemap = [
           {
             url: `${baseUrl}${basePath}`,
-            lastModified: new Date(),
+            ...(lastCommit
+              ? { lastModified: new Date(lastCommit) }
+              : {}),
             changeFrequency: 'weekly',
             priority: 0.8,
           },
@@ -47,9 +66,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
             continue
           }
 
+          // No per-item date exists upstream, so we inherit the repo's push
+          // date rather than invent one. Absent is better than wrong: a false
+          // lastmod is the fastest way to get the whole file discounted.
           urls.push({
             url: `${baseUrl}${basePath}/${item.name}`,
-            lastModified: new Date(),
+            ...(lastCommit ? { lastModified: new Date(lastCommit) } : {}),
             changeFrequency: 'monthly',
             priority: 0.6,
           })

--- a/apps/web/components/json-ld.tsx
+++ b/apps/web/components/json-ld.tsx
@@ -1,0 +1,26 @@
+// Serialises schema.org nodes into the <script type="application/ld+json">
+// tag crawlers read. Accepts one node or several; multiple nodes are emitted
+// as a single JSON array, which is valid JSON-LD and keeps the DOM to one tag.
+
+type JsonLdNode = Record<string, unknown>
+
+/**
+ * Registry names and item descriptions are third-party strings from
+ * directory.json and remote registry.json files, so they reach this component
+ * untrusted. Escaping `<` closes the `</script>` breakout, and the JSON-LD
+ * parser resolves the < escape back to the original character.
+ */
+function serialise(payload: JsonLdNode | JsonLdNode[]): string {
+  return JSON.stringify(payload).replace(/</g, "\\u003c")
+}
+
+export function JsonLd({ data }: { data: JsonLdNode | JsonLdNode[] }) {
+  if (Array.isArray(data) && data.length === 0) return null
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serialise(data) }}
+    />
+  )
+}

--- a/apps/web/components/registry-slug-view.tsx
+++ b/apps/web/components/registry-slug-view.tsx
@@ -9,10 +9,16 @@ import {
   groupItemsByCategory,
   SLUG_TO_REGISTRY_TYPE,
   REGISTRY_TYPE_LABELS,
+  singularType,
 } from "@/lib/registry-mappings"
 import { registryFetch } from "@/lib/fetch-utils"
 import { getAffiliates } from "@/lib/affiliates"
 import { fetchRegistryIndex } from "@/lib/resolve-registry"
+import { JsonLd } from "@/components/json-ld"
+import {
+  buildBreadcrumbSchema,
+  buildRegistryItemSchema,
+} from "@/lib/structured-data"
 
 export function isCategory(slug: string): boolean {
   return slug in SLUG_TO_REGISTRY_TYPE
@@ -56,10 +62,14 @@ export async function buildSlugMetadata(
 
   if (isCategory(slug)) {
     const categoryLabel = REGISTRY_TYPE_LABELS[slug] || slug
+    const title = `shadcn ${categoryLabel.toLowerCase()} — ${registry.name}`
+    const description = `Browse shadcn/ui ${categoryLabel.toLowerCase()} from ${registry.name}. Preview the source and install with the shadcn CLI.`
     return {
-      title: `${categoryLabel} - ${registry.name}`,
-      description: `Browse ${categoryLabel.toLowerCase()} from ${registry.name}.`,
+      title,
+      description,
       alternates: { canonical },
+      openGraph: { title, description, url: canonical, type: "website" },
+      twitter: { card: "summary_large_image", title, description },
     }
   }
 
@@ -71,20 +81,27 @@ export async function buildSlugMetadata(
     ? REGISTRY_TYPE_LABELS[categorySlug] || categorySlug
     : "Component"
 
+  // An item slug on its own ("dashboard-01") matches no query. Pairing it with
+  // the shadcn qualifier and the registry name is what makes the long tail
+  // reachable — these are the bulk of our indexable URLs.
+  const noun = singularType(categoryLabel)
+  const title = `${slug} — shadcn ${noun} · ${registry.name}`
+  const description = `${itemData?.description || slug}: a shadcn/ui ${noun} from ${registry.name}. Preview the source and install it with the shadcn CLI.`
+
   return {
-    title: `${slug} - ${categoryLabel}`,
-    description: `${itemData?.description || slug}: A ${categoryLabel.toLowerCase()} from ${registry.name}. Preview code and install with one command.`,
+    title,
+    description,
     alternates: { canonical },
     openGraph: {
-      title: `${slug} - ${registry.name}`,
-      description: `${itemData?.description || slug}: A ${categoryLabel.toLowerCase()} from ${registry.name}.`,
+      title,
+      description,
       url: canonical,
       type: "website",
     },
     twitter: {
       card: "summary_large_image",
-      title: `${slug} - ${registry.name}`,
-      description: `${itemData?.description || slug}: A ${categoryLabel.toLowerCase()} from ${registry.name}.`,
+      title,
+      description,
     },
   }
 }
@@ -128,15 +145,25 @@ export async function RegistrySlugView({
       items: categoryItems,
     }
 
+    const categoryLabel = REGISTRY_TYPE_LABELS[slug] || slug
+
     return (
-      <RegistryViewer
-        registry={registry}
-        registryIndex={filteredRegistry}
-        selectedItem={null}
-        currentCategory={slug}
-        affiliate={affiliate}
-        basePath={basePath}
-      />
+      <>
+        <JsonLd
+          data={buildBreadcrumbSchema([
+            { name: registry.name, path: basePath },
+            { name: categoryLabel, path: `${basePath}/${slug}` },
+          ])}
+        />
+        <RegistryViewer
+          registry={registry}
+          registryIndex={filteredRegistry}
+          selectedItem={null}
+          currentCategory={slug}
+          affiliate={affiliate}
+          basePath={basePath}
+        />
+      </>
     )
   }
 
@@ -158,14 +185,35 @@ export async function RegistrySlugView({
     items: categoryItems,
   }
 
+  const categoryLabel = REGISTRY_TYPE_LABELS[currentCategory] || currentCategory
+
   return (
-    <RegistryViewer
-      registry={registry}
-      registryIndex={filteredRegistry}
-      selectedItem={itemData}
-      currentCategory={currentCategory}
-      affiliate={affiliate}
-      basePath={basePath}
-    />
+    <>
+      <JsonLd
+        data={[
+          buildBreadcrumbSchema([
+            { name: registry.name, path: basePath },
+            { name: categoryLabel, path: `${basePath}/${currentCategory}` },
+            { name: slug, path: `${basePath}/${slug}` },
+          ]),
+          buildRegistryItemSchema({
+            registry,
+            basePath,
+            slug,
+            description: itemData.description,
+            categoryLabel,
+            dependencies: itemData.dependencies,
+          }),
+        ]}
+      />
+      <RegistryViewer
+        registry={registry}
+        registryIndex={filteredRegistry}
+        selectedItem={itemData}
+        currentCategory={currentCategory}
+        affiliate={affiliate}
+        basePath={basePath}
+      />
+    </>
   )
 }

--- a/apps/web/lib/registry-mappings.ts
+++ b/apps/web/lib/registry-mappings.ts
@@ -109,6 +109,19 @@ export const REGISTRY_TYPE_LABELS: Record<string, string> = {
 }
 
 /**
+ * Singular form of a REGISTRY_TYPE_LABELS value, for prose that describes one
+ * item ("a shadcn block") rather than a category ("Blocks"). Handles the -ies
+ * plural so "Utilities" becomes "utility"; labels that are already singular
+ * ("Base") pass through untouched.
+ */
+export function singularType(label: string): string {
+  const lower = label.toLowerCase()
+  if (lower.endsWith("ies")) return `${lower.slice(0, -3)}y`
+  if (lower.endsWith("s")) return lower.slice(0, -1)
+  return lower
+}
+
+/**
  * Relevance-based ordering: installable → configuration → reference → other
  */
 export const REGISTRY_TYPE_ORDER: string[] = [

--- a/apps/web/lib/seo.ts
+++ b/apps/web/lib/seo.ts
@@ -1,0 +1,68 @@
+// Single source of truth for the site-level SEO surface. Every route that
+// builds metadata or structured data reads its constants from here so the
+// canonical host, the site name and the description can never drift apart
+// across layout, page metadata, JSON-LD and the OG tags.
+
+export const SITE_URL = "https://registry.directory"
+
+export const SITE_NAME = "registry.directory"
+
+export const SITE_TAGLINE =
+  "Discover shadcn/ui registries, components and blocks"
+
+export const SITE_DESCRIPTION =
+  "Search the whole shadcn/ui registry ecosystem in one place. Browse components, blocks, themes and templates across every public registry, preview the source in an IDE viewer, then copy the shadcn CLI install command."
+
+/**
+ * Head terms the directory actually competes for, ordered by intent: the
+ * registry vocabulary it already ranks for first, then the artefact nouns
+ * developers search when they don't know the word "registry", then the stack
+ * they filter by. `keywords` carries no weight with Google, but Bing and the
+ * AI crawlers that read our llms.txt still parse it, and it costs one array.
+ */
+export const SITE_KEYWORDS = [
+  "shadcn registry",
+  "shadcn registries",
+  "shadcn ui registry",
+  "shadcn registry directory",
+  "shadcn components",
+  "shadcn blocks",
+  "shadcn templates",
+  "shadcn themes",
+  "shadcn component library",
+  "shadcn ui components",
+  "registry.json",
+  "shadcn cli",
+  "shadcn mcp",
+  "react component library",
+  "next.js components",
+  "tailwind css components",
+  "radix ui",
+  "base ui",
+  "copy paste components",
+]
+
+export const SITE_AUTHOR = {
+  name: "rbadillap",
+  url: "https://github.com/rbadillap",
+}
+
+// Inferred from the GitHub handle — confirm this matches the actual X account
+// before relying on it, since twitter:site is what attributes card impressions.
+export const TWITTER_HANDLE = "@rbadillap"
+
+/**
+ * Titles qualify a registry with "shadcn/ui" so the name alone isn't the only
+ * thing matching, but a good share of the directory is already named for it
+ * ("shadcn/ui", "shadcn/studio", "ShadcnCraft"). Repeating the qualifier there
+ * produces "shadcn/ui — shadcn/ui registry", which reads as spam and wastes
+ * the pixels a SERP gives a title. Drop it when the name already carries it.
+ */
+export function shadcnQualifier(registryName: string): string {
+  return /shadcn/i.test(registryName) ? "" : "shadcn/ui "
+}
+
+/** Absolute URL for a site-relative path, collapsing the double slash. */
+export function absoluteUrl(path = "/"): string {
+  return `${SITE_URL}${path.startsWith("/") ? path : `/${path}`}`
+}

--- a/apps/web/lib/seo.ts
+++ b/apps/web/lib/seo.ts
@@ -7,11 +7,13 @@ export const SITE_URL = "https://registry.directory"
 
 export const SITE_NAME = "registry.directory"
 
-export const SITE_TAGLINE =
-  "Discover shadcn/ui registries, components and blocks"
+export const SITE_TAGLINE = "The explorer for the shadcn registry ecosystem"
 
+// Leads with the tagline verbatim, then spends the rest of the ~160 chars a
+// SERP snippet allows on the nouns people search and on what the site lets
+// them do once they arrive.
 export const SITE_DESCRIPTION =
-  "Search the whole shadcn/ui registry ecosystem in one place. Browse components, blocks, themes and templates across every public registry, preview the source in an IDE viewer, then copy the shadcn CLI install command."
+  "The explorer for the shadcn registry ecosystem. Browse components, blocks and themes across every public registry, preview the code, copy the install command."
 
 /**
  * Head terms the directory actually competes for, ordered by intent: the

--- a/apps/web/lib/structured-data.ts
+++ b/apps/web/lib/structured-data.ts
@@ -1,0 +1,233 @@
+// JSON-LD builders. Each returns a plain schema.org node; routes hand the
+// result to <JsonLd> to serialise it. Kept free of React so metadata code and
+// route components can share the same shapes.
+//
+// Type choices, and why:
+//   WebSite + SearchAction  — declares the site's own search endpoint (`?q=`)
+//   Organization            — binds the brand to its GitHub/social profiles
+//   BreadcrumbList          — swaps the raw URL in the SERP for a trail
+//   CollectionPage/ItemList — a registry landing is an enumerable collection
+//   SoftwareSourceCode      — an item page *is* source code, not an article
+//
+// Deliberately absent: FAQPage. Google restricted it to recognised-authority
+// sites in 2023, so emitting it buys nothing and adds markup to maintain.
+
+import type { DirectoryEntry } from "@/lib/types"
+import {
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_URL,
+  absoluteUrl,
+  shadcnQualifier,
+} from "@/lib/seo"
+
+type JsonLdNode = Record<string, unknown>
+
+const SCHEMA = "https://schema.org"
+
+/** Drop undefined/empty values so we never emit a null-valued schema key. */
+function compact(node: JsonLdNode): JsonLdNode {
+  return Object.fromEntries(
+    Object.entries(node).filter(
+      ([, value]) =>
+        value !== undefined &&
+        value !== null &&
+        value !== "" &&
+        !(Array.isArray(value) && value.length === 0)
+    )
+  )
+}
+
+/**
+ * The site node, with the search endpoint the home page already implements via
+ * the `q` param. Whether Google renders a sitelinks searchbox is its call, but
+ * the declaration is a prerequisite for it ever happening.
+ */
+export function buildWebSiteSchema(): JsonLdNode {
+  return {
+    "@context": SCHEMA,
+    "@type": "WebSite",
+    "@id": `${SITE_URL}/#website`,
+    name: SITE_NAME,
+    alternateName: "shadcn registry directory",
+    url: SITE_URL,
+    description: SITE_DESCRIPTION,
+    inLanguage: "en",
+    publisher: { "@id": `${SITE_URL}/#organization` },
+    potentialAction: {
+      "@type": "SearchAction",
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: `${SITE_URL}/?q={search_term_string}`,
+      },
+      "query-input": "required name=search_term_string",
+    },
+  }
+}
+
+export function buildOrganizationSchema(): JsonLdNode {
+  return {
+    "@context": SCHEMA,
+    "@type": "Organization",
+    "@id": `${SITE_URL}/#organization`,
+    name: SITE_NAME,
+    url: SITE_URL,
+    description: SITE_DESCRIPTION,
+    logo: absoluteUrl("/icon"),
+    sameAs: ["https://github.com/rbadillap/registry.directory"],
+  }
+}
+
+/**
+ * The home page as an enumerable catalogue of registries. This is the node
+ * that tells a crawler the directory has N distinct entries rather than one
+ * marketing page, and it gives each registry an anchor from the root.
+ */
+export function buildDirectoryListSchema(
+  registries: ReadonlyArray<{ name: string; description?: string; path: string }>
+): JsonLdNode {
+  return {
+    "@context": SCHEMA,
+    "@type": "CollectionPage",
+    "@id": `${SITE_URL}/#directory`,
+    name: `${SITE_NAME} — shadcn/ui registry directory`,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    isPartOf: { "@id": `${SITE_URL}/#website` },
+    mainEntity: {
+      "@type": "ItemList",
+      name: "shadcn/ui registries",
+      numberOfItems: registries.length,
+      itemListElement: registries.map((registry, index) =>
+        compact({
+          "@type": "ListItem",
+          position: index + 1,
+          name: registry.name,
+          description: registry.description,
+          url: absoluteUrl(registry.path),
+        })
+      ),
+    },
+  }
+}
+
+/**
+ * Breadcrumbs for a nested route. Pass the trail without the site root — it is
+ * prepended here so every page agrees on position 1.
+ */
+export function buildBreadcrumbSchema(
+  trail: ReadonlyArray<{ name: string; path: string }>
+): JsonLdNode {
+  const crumbs = [{ name: "Registries", path: "/" }, ...trail]
+
+  return {
+    "@context": SCHEMA,
+    "@type": "BreadcrumbList",
+    itemListElement: crumbs.map((crumb, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: crumb.name,
+      item: absoluteUrl(crumb.path),
+    })),
+  }
+}
+
+/**
+ * A registry landing: the collection itself, plus an ItemList naming the
+ * components it ships. The list is capped because a landing with thousands of
+ * items would otherwise emit a payload larger than the page it describes.
+ */
+export function buildRegistryCollectionSchema({
+  registry,
+  basePath,
+  itemNames,
+  totalItems,
+}: {
+  registry: DirectoryEntry
+  basePath: string
+  itemNames: ReadonlyArray<string>
+  totalItems: number
+}): JsonLdNode {
+  const canonical = absoluteUrl(basePath)
+  const listed = itemNames.slice(0, 100)
+
+  return compact({
+    "@context": SCHEMA,
+    "@type": "CollectionPage",
+    "@id": `${canonical}#collection`,
+    name: `${registry.name} — ${shadcnQualifier(registry.name)}registry`,
+    description:
+      registry.description ||
+      `Browse ${totalItems} shadcn/ui components from ${registry.name}.`,
+    url: canonical,
+    isPartOf: { "@id": `${SITE_URL}/#website` },
+    about: compact({
+      "@type": "SoftwareSourceCode",
+      name: registry.name,
+      description: registry.description,
+      codeRepository: registry.github_url,
+      url: registry.url,
+      programmingLanguage: "TypeScript",
+      runtimePlatform: "React",
+    }),
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: totalItems,
+      itemListElement: listed.map((name, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name,
+        url: absoluteUrl(`${basePath}/${name}`),
+      })),
+    },
+  })
+}
+
+/**
+ * An individual component. SoftwareSourceCode is the honest type here: the
+ * page's payload is installable source, and `isPartOf` ties it back to the
+ * registry collection so the two nodes form a graph rather than two islands.
+ */
+export function buildRegistryItemSchema({
+  registry,
+  basePath,
+  slug,
+  description,
+  categoryLabel,
+  dependencies,
+}: {
+  registry: DirectoryEntry
+  basePath: string
+  slug: string
+  description?: string
+  categoryLabel: string
+  dependencies?: ReadonlyArray<string>
+}): JsonLdNode {
+  const canonical = absoluteUrl(`${basePath}/${slug}`)
+
+  return compact({
+    "@context": SCHEMA,
+    "@type": "SoftwareSourceCode",
+    "@id": `${canonical}#component`,
+    name: slug,
+    description:
+      description ||
+      `${slug}: a shadcn/ui ${categoryLabel.toLowerCase()} from ${registry.name}.`,
+    url: canonical,
+    codeRepository: registry.github_url,
+    programmingLanguage: "TypeScript",
+    runtimePlatform: "React",
+    applicationCategory: "DeveloperApplication",
+    isPartOf: compact({
+      "@type": "CollectionPage",
+      name: registry.name,
+      url: absoluteUrl(basePath),
+    }),
+    author: compact({
+      "@type": "Organization",
+      name: registry.name,
+      url: registry.url,
+    }),
+    softwareRequirement: dependencies?.slice(0, 25),
+  })
+}


### PR DESCRIPTION
## Why

The site shipped **zero structured data** and **zero `keywords`** — `grep` for `application/ld+json` across the app returned nothing. It ranked on domain authority and brand, not on semantic coverage.

Two other gaps showed up along the way:

- Item titles were `${slug} - ${categoryLabel}` → `dashboard-01 - Block`. A bare slug matches no query, and item pages are the bulk of our indexable URLs.
- `sitemap.ts` stamped `lastModified: new Date()` on **every** entry on **every** daily rebuild, telling crawlers the whole directory changed daily. That's how a sitemap trains Google to ignore its own `lastmod`.

## What changed

### Metadata

`apps/web/lib/seo.ts` is now the single source of truth for the site-level SEO surface, so the canonical host, name and description can't drift across layout, page metadata, JSON-LD and OG tags.

Root layout gains `applicationName`, `authors`, `creator`, `publisher`, `keywords`, `openGraph.siteName`/`locale`, `twitter.site`/`creator`, and `robots` with `max-snippet: -1` + `max-image-preview: large`.

Titles now lead with terms people search:

| Page | Before | After |
|---|---|---|
| Home | `registry.directory - The explorer for shadcn/ui registries` | `registry.directory — The explorer for the shadcn registry ecosystem` |
| Registry | `Magic UI` | `Magic UI — 150 shadcn/ui components & blocks` |
| Item | `marquee - Components` | `marquee — shadcn component · Magic UI` |

`shadcnQualifier()` drops the qualifier when a registry is already named for shadcn — **14 of 74 registries are** (`shadcn/ui`, `ShadcnCraft`, `Shadcn Dashboard`…), which otherwise produced `shadcn/ui — shadcn/ui registry`. Repeated tokens waste scarce title pixels and are a signal that gets titles rewritten by Google.

### Structured data

New `lib/structured-data.ts`, rendered by `<JsonLd>`:

- `WebSite` + `SearchAction` + `Organization` — site-wide, referenced by `@id`
- `CollectionPage` + `ItemList` enumerating the directory on the home page
- `BreadcrumbList` on every nested route — replaces the raw URL in the SERP with a trail
- `SoftwareSourceCode` per item, tied to its registry via `isPartOf`

`FAQPage` is deliberately absent: Google restricted it to recognised-authority sites in 2023, so it'd be markup to maintain for no rich result.

Third-party strings (registry names, item descriptions from remote `registry.json`) reach `<JsonLd>` untrusted, so `<` is escaped to close the `</script>` breakout.

### Sitemap

Registry and item URLs inherit the upstream repo's push date from the cached `github.json`, and **omit** `lastModified` entirely when no real date exists. Absent beats wrong — a false `lastmod` is the fastest way to get the whole file discounted.

## Verification

- `tsc --noEmit` clean
- `pnpm --filter web lint` — no new warnings
- JSON-LD confirmed in rendered HTML: home emits `WebSite` + `Organization` + `CollectionPage` with 73 registries; registry landings emit `BreadcrumbList` + `CollectionPage`
- Title stutter fix confirmed on `/shadcn-ui/ui` and `/magicuidesign/magicui`
- Item-page builders unit-checked in isolation

**Not verified end-to-end:** item pages 404 in the dev sandbox because outbound fetches to remote registries are blocked there (48 `AbortError`s), so `numberOfItems` renders as 0 locally. The code degrades gracefully, but the item route's JSON-LD should be spot-checked on a preview deploy.

**One thing to confirm before merge:** `TWITTER_HANDLE` in `lib/seo.ts` was inferred from the GitHub handle. `twitter:site` is what attributes card impressions, so it's worth checking it matches the real X account.

## Follow-ups (not in this PR)

Cross-registry category pages (`/blocks`, `/dashboards`, `/themes`) — one dimension at a time with a minimum item threshold, not a `component × use-case × technology` cartesian product, which would land in scaled-content-abuse territory and risk the curated-directory standing this site trades on.

---
_Generated by [Claude Code](https://claude.ai/code/session_017RuHJjwamJWP2u1Vr6MN2i)_