### PR TITLE
feat: add Zyeon UI registry

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -948,7 +948,7 @@
     },
     {
       "name": "21st.dev Agent Elements",
-      "description": "Open-source registry of agent UI primitives — chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan), clarifying questions, input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK.",
+      "description": "Open-source registry of agent UI primitives \u2014 chat shell, tool-call cards (Bash, Edit, Search, Todo, Plan), clarifying questions, input bar, streaming markdown. Built on React 19, Tailwind v4, and the Vercel AI SDK.",
       "url": "https://agent-elements.21st.dev",
       "registry_url": "https://agent-elements.21st.dev/r/index.json",
       "github_url": "https://github.com/21st-dev/agent-elements",
@@ -1274,6 +1274,22 @@
         "agent-audio-visualizer-bar",
         "agent-session-view-01",
         "start-audio-button"
+      ]
+    },
+    {
+      "name": "Zyeon UI",
+      "description": "353 React + Tailwind components \u2014 each ships with live preview, full source, its generation prompt and a concept map. Installable via the shadcn CLI or by AI agents over MCP.",
+      "url": "https://ui.zyeon.ai",
+      "registry_url": "https://ui.zyeon.ai/r/registry.json",
+      "github_url": "https://github.com/Zyeon-AI/zyeon-ui-components",
+      "github_profile": "https://github.com/Zyeon-AI.png",
+      "namespace": "@zyeon",
+      "featured": [
+        "hold-to-confirm",
+        "credit-card",
+        "comparison-slider",
+        "dock",
+        "otp-input"
       ]
     }
   ]


### PR DESCRIPTION
Adds **Zyeon UI** — a shadcn-compatible registry of 353 React + Tailwind components where every item ships with live preview, full source in semantic tokens, the generation prompt that produced it, and a concept map of the interaction.

- Site: https://ui.zyeon.ai
- Registry index: https://ui.zyeon.ai/r/registry.json (free items install with no auth via `npx shadcn add`)
- Namespace: `@zyeon`
- Also exposes an MCP server so agents can search the catalog by intent: https://ui.zyeon.ai/guides/install-ui-components-via-mcp

Featured items are all free-tier and installable without a token.