### PR TITLE
feat: add Motion Menu registry

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -1291,6 +1291,20 @@
         "dock",
         "otp-input"
       ]
+    },
+    {
+      "name": "Motion Menu",
+      "description": "596 motion/3D UI patterns — scroll-driven WebGL, shader passes, spring choreography — as ready HTML/CSS/JS, or over MCP.",
+      "url": "https://motion-menu-two.vercel.app",
+      "registry_url": "https://motion-menu-two.vercel.app/r/registry.json",
+      "namespace": "@motion-menu",
+      "featured": [
+        "custom-cursor",
+        "preloader",
+        "page-transition",
+        "moodboard-composer",
+        "corner-anchored-nav"
+      ]
     }
   ]
 }

--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -1294,9 +1294,9 @@
     },
     {
       "name": "Motion Menu",
-      "description": "596 motion/3D UI patterns — scroll-driven WebGL, shader passes, spring choreography — as ready HTML/CSS/JS, or over MCP.",
-      "url": "https://motion-menu-two.vercel.app",
-      "registry_url": "https://motion-menu-two.vercel.app/r/registry.json",
+      "description": "597 motion/3D UI patterns — scroll-driven WebGL, shader passes, spring choreography — as ready HTML/CSS/JS, or over MCP.",
+      "url": "https://www.motionmenu.ca",
+      "registry_url": "https://www.motionmenu.ca/r/registry.json",
       "namespace": "@motion-menu",
       "featured": [
         "custom-cursor",


### PR DESCRIPTION
Adds Motion Menu — 596 motion/3D UI patterns (scroll-driven WebGL, shader passes, spring choreography) as ready HTML/CSS/JS, installable via the shadcn CLI or over MCP.

- Site: https://motion-menu-two.vercel.app
- Registry: https://motion-menu-two.vercel.app/r/registry.json
- Free tier: 26 patterns, no key; $149 once for the rest

`github_url` omitted — the source repo isn't public yet, so the entry points at the live site and registry endpoint instead, matching the existing pattern used by entries like Aceternity UI and shadcn-form.com.