### PR TITLE
motion-menu: featured patterns now all resolve for anonymous readers

### DIFF
--- a/apps/web/public/directory.json
+++ b/apps/web/public/directory.json
@@ -1315,11 +1315,11 @@
       "registry_url": "https://www.motionmenu.ca/r/registry.json",
       "namespace": "@motion-menu",
       "featured": [
+        "lenis-scrolltrigger-bridge",
         "custom-cursor",
         "preloader",
-        "page-transition",
-        "moodboard-composer",
-        "corner-anchored-nav"
+        "particle-field",
+        "command-palette-wired-whole-menu"
       ]
     },
     {


### PR DESCRIPTION
Follow-up to #125 (merged by hand — thank you). You flagged that `page-transition`, `moodboard-composer` and `corner-anchored-nav` return 402 to anonymous readers, rendering empty in the viewer.

This PR swaps them for free-tier patterns that cold-verify **200 with no key**:
- `lenis-scrolltrigger-bridge` (01)
- `custom-cursor` (02)
- `preloader` (03)
- `particle-field` (27)
- `command-palette-wired-whole-menu` (149)

All five verified anonymously just now via `https://www.motionmenu.ca/r/<slug>.json`.